### PR TITLE
feat: implement SwapperV2

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^5.3.0"
+    "@openzeppelin/contracts": "^5.3.0",
+    "@uniswap/v2-periphery": "^1.1.0-beta.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "package.json": "sort-package-json"
   },
   "dependencies": {
+    "@defi-wonderland/smock-foundry": "^1.5.0",
     "@openzeppelin/contracts": "^5.3.0",
     "@uniswap/v2-periphery": "^1.1.0-beta.0"
   },

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,5 +1,7 @@
-forge-std/=node_modules/forge-std/src
+@uniswap/v2-periphery/=node_modules/@uniswap/v2-periphery/contracts/
 @openzeppelin/=node_modules/@openzeppelin/contracts/
+
+forge-std/=node_modules/forge-std/src
 halmos-cheatcodes=node_modules/halmos-cheatcodes
 
 contracts/=src/contracts

--- a/src/contracts/SwapperV1.sol
+++ b/src/contracts/SwapperV1.sol
@@ -30,12 +30,12 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
   mapping(address user => SwapInfo swapInfo) private _userToSwapInfo;
 
   modifier onlyBeforeSwap() {
-    if (swapped) revert SwapperV1_SwapAlreadyExecuted();
+    if (swapped) revert Swapper_SwapAlreadyExecuted();
     _;
   }
 
   modifier onlyAfterSwap() {
-    if (!swapped) revert SwapperV1_SwapNotExecuted();
+    if (!swapped) revert Swapper_SwapNotExecuted();
     _;
   }
 
@@ -44,7 +44,7 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
     //////////////////////////////////////////////////////////////*/
 
   constructor(address _depositedToken, address _swappedToken) Ownable(msg.sender) {
-    if (_depositedToken == _swappedToken) revert SwapperV1_InvalidTokens();
+    if (_depositedToken == _swappedToken) revert Swapper_InvalidTokens();
 
     DEPOSITED_TOKEN = _depositedToken;
     SWAPPED_TOKEN = _swappedToken;
@@ -56,15 +56,15 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
 
   /// @inheritdoc ISwapper
   function deposit(uint256 _amount) external payable onlyBeforeSwap {
-    if (_amount == 0) revert SwapperV1_InvalidAmount();
+    if (_amount == 0) revert Swapper_InvalidAmount();
 
     SwapInfo storage _swapInfo = _userToSwapInfo[msg.sender];
 
     // Ensure funds are deposited to the swapper contract
     if (DEPOSITED_TOKEN == address(0)) {
-      if (msg.value != _amount) revert SwapperV1_AmountMismatch();
+      if (msg.value != _amount) revert Swapper_AmountMismatch();
     } else {
-      if (msg.value != 0) revert SwapperV1_AmountMismatch();
+      if (msg.value != 0) revert Swapper_AmountMismatch();
       // TODO: Can add IERC20Permit but not needed for now
       IERC20(DEPOSITED_TOKEN).safeTransferFrom(msg.sender, address(this), _amount);
     }
@@ -86,7 +86,7 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
 
     // Expect liquidity to be equal to the deposited token balance (1:1 swap)
     if (_tokenBalance != _getTokenBalance(SWAPPED_TOKEN)) {
-      revert SwapperV1_NotEnoughLiquidity();
+      revert Swapper_NotEnoughLiquidity();
     }
 
     // Set the swapped flag to true
@@ -109,7 +109,7 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
 
     uint256 _withdrawAmount = _swapInfo.depositTokenAmount;
 
-    if (_withdrawAmount == 0) revert SwapperV1_NoTokensToWithdraw();
+    if (_withdrawAmount == 0) revert Swapper_NoTokensToWithdraw();
 
     // Delete the swap
     delete _userToSwapInfo[msg.sender];
@@ -129,9 +129,9 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
   function withdraw() external onlyAfterSwap nonReentrant {
     SwapInfo storage _swapInfo = _userToSwapInfo[msg.sender];
 
-    if (_swapInfo.hasWithdrawn) revert SwapperV1_AlreadyWithdrawn();
+    if (_swapInfo.hasWithdrawn) revert Swapper_AlreadyWithdrawn();
 
-    if (_swapInfo.depositTokenAmount == 0) revert SwapperV1_NoTokensToWithdraw();
+    if (_swapInfo.depositTokenAmount == 0) revert Swapper_NoTokensToWithdraw();
 
     uint256 _swapTokenAmount = _getSwapTokenAmount(msg.sender);
 
@@ -151,9 +151,9 @@ contract SwapperV1 is ISwapper, Ownable, ReentrancyGuard {
 
   /// @inheritdoc ISwapper
   function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
-    if (amount == 0) revert SwapperV1_NoTokensToWithdraw();
+    if (amount == 0) revert Swapper_NoTokensToWithdraw();
 
-    if (_getTokenBalance(token) < amount) revert SwapperV1_NotEnoughLiquidity();
+    if (_getTokenBalance(token) < amount) revert Swapper_NotEnoughLiquidity();
 
     if (token == address(0)) {
       payable(msg.sender).transfer(amount);

--- a/src/contracts/SwapperV2.sol
+++ b/src/contracts/SwapperV2.sol
@@ -124,18 +124,24 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
 
   /// @inheritdoc ISwapperV2
   function withdrawDeposit() external nonReentrant {
-    Deposits[] memory _deposits = _userDeposits[msg.sender];
-    uint256 _totalDeposits = _deposits.length;
+    Deposits[] storage _deposits = _userDeposits[msg.sender];
     uint256 _withdrawableAmount = 0;
 
-    for (uint256 i = 0; i < _totalDeposits; i++) {
-      _withdrawableAmount += _deposits[i].amount;
+    uint256 i = 0;
+    while (i < _deposits.length) {
+      if (_deposits[i].swapIndex >= _swapIndex) {
+        _withdrawableAmount += _deposits[i].amount;
+
+        // Remove the element by swapping with the last and popping
+        _deposits[i] = _deposits[_deposits.length - 1];
+        _deposits.pop();
+        // Do not increment i since the new item at i needs to be checked
+      } else {
+          i++;
+      }
     }
 
     if (_withdrawableAmount == 0) revert Swapper_NoTokensToWithdraw();
-
-    // Delete the deposits for the user
-    delete _userDeposits[msg.sender];
 
     // Withdraw the tokens
     if (DEPOSITED_TOKEN == address(0)) {

--- a/src/contracts/SwapperV2.sol
+++ b/src/contracts/SwapperV2.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+// External Imports
+import {Ownable} from '@openzeppelin/access/Ownable.sol';
+import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/token/ERC20/utils/SafeERC20.sol';
+import {ReentrancyGuard} from '@openzeppelin/utils/ReentrancyGuard.sol';
+import {IUniswapV2Router02} from '@uniswap/v2-periphery/interfaces/IUniswapV2Router02.sol';
+
+// Internal Imports
+import {ISwapperV2} from 'interfaces/ISwapperV2.sol';
+
+contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
+  using SafeERC20 for IERC20;
+
+  /*///////////////////////////////////////////////////////////////
+                            Storage
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice The router to be used for swapping
+  IUniswapV2Router02 public immutable ROUTER;
+
+  /// @notice Index of the current swap
+  uint256 internal _swapIndex;
+
+  /// @inheritdoc ISwapperV2
+  address public immutable DEPOSITED_TOKEN;
+
+  /// @inheritdoc ISwapperV2
+  address public immutable SWAPPED_TOKEN;
+
+  /// @notice Mapping of user to thier deposited by swap index
+  mapping(address user => Deposits[] deposits) private _userDeposits;
+
+  /// @notice Mapping of user to withdrawable balance
+  mapping(address user => uint256 amount) private _userWithdrawableBalance;
+
+  /// @notice Mapping of swap index to the swap rate
+  mapping(uint256 swapIndex => SwapRateInfo swapRateInfo) private _swaps;
+
+  /*///////////////////////////////////////////////////////////////
+                            Constructor
+  //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Constructor
+   * @param _depositedToken The address of the token to be deposited
+   * @param _swappedToken The address of the token to be swapped
+   * @param _router The address of the router to be used for swapping
+   */
+  constructor(address _depositedToken, address _swappedToken, address _router) Ownable(msg.sender) {
+    if (_depositedToken == _swappedToken) revert Swapper_InvalidTokens();
+
+    DEPOSITED_TOKEN = _depositedToken;
+    SWAPPED_TOKEN = _swappedToken;
+    ROUTER = IUniswapV2Router02(_router);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                            External Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @inheritdoc ISwapperV2
+  function deposit(uint256 _amount) external payable {
+    if (_amount == 0) revert Swapper_InvalidAmount();
+
+    // Ensure funds are deposited to the swapper contract
+    if (DEPOSITED_TOKEN == address(0)) {
+      if (msg.value != _amount) revert Swapper_AmountMismatch();
+    } else {
+      if (msg.value != 0) revert Swapper_AmountMismatch();
+      IERC20(DEPOSITED_TOKEN).safeTransferFrom(msg.sender, address(this), _amount);
+    }
+
+    // Add the deposit to the user's deposits by swap index
+    _userDeposits[msg.sender].push(Deposits({amount: _amount, swapIndex: _swapIndex}));
+
+    emit TokensDeposited(msg.sender, _amount);
+  }
+
+  /// @inheritdoc ISwapperV2
+  function swap() external payable override onlyOwner nonReentrant {
+    address[] memory path = _constructTokenPath();
+
+    uint256 _totalDeposited = _getTokenBalance(DEPOSITED_TOKEN);
+    uint256 _totalBalanceBeforeSwapping = _getTokenBalance(SWAPPED_TOKEN);
+
+    if (DEPOSITED_TOKEN == address(0)) {
+      // swapping ETH -> token
+      ROUTER.swapExactETHForTokens{value: _totalDeposited}(0, path, address(this), block.timestamp);
+    } else {
+      // Approve the router to spend the deposited tokens
+      IERC20(DEPOSITED_TOKEN).approve(address(ROUTER), _totalDeposited);
+
+      if (SWAPPED_TOKEN == address(0)) {
+        // Swapping token -> ETH
+        ROUTER.swapExactTokensForETH(
+          _totalDeposited,
+          0, // Note: min amount out should be passed in as arg
+          path,
+          address(this),
+          block.timestamp
+        );
+      } else {
+        // Swapping token -> token
+        ROUTER.swapExactTokensForTokens(
+          _totalDeposited,
+          0, // Note: min amount out should be passed in as arg
+          path,
+          address(this),
+          block.timestamp
+        );
+      }
+    }
+
+    uint256 _totalSwapped = _getTokenBalance(SWAPPED_TOKEN) - _totalBalanceBeforeSwapping;
+
+    // Store the swap rate information
+    _swaps[_swapIndex] = SwapRateInfo({totalDeposited: _totalDeposited, totalSwapped: _totalSwapped});
+
+    // Increment the swap index
+    _swapIndex++;
+
+    emit TokensSwapped(_totalDeposited, _totalSwapped);
+  }
+
+  /// @inheritdoc ISwapperV2
+  function withdrawDeposit() external nonReentrant {
+    Deposits[] memory _deposits = _userDeposits[msg.sender];
+    uint256 _totalDeposits = _deposits.length;
+    uint256 _withdrawableAmount = 0;
+
+    for (uint256 i = 0; i < _totalDeposits; i++) {
+      _withdrawableAmount += _deposits[i].amount;
+    }
+
+    if (_withdrawableAmount == 0) revert Swapper_NoTokensToWithdraw();
+
+    // Delete the deposits for the user
+    delete _userDeposits[msg.sender];
+
+    // Withdraw the tokens
+    if (DEPOSITED_TOKEN == address(0)) {
+      payable(msg.sender).transfer(_withdrawableAmount);
+    } else {
+      IERC20(DEPOSITED_TOKEN).safeTransfer(msg.sender, _withdrawableAmount);
+    }
+
+    // Emit the event
+    emit DepositWithdrawn(msg.sender, _withdrawableAmount);
+  }
+
+  /// @inheritdoc ISwapperV2
+  function withdraw() external nonReentrant {
+    // Get the deposits for the user
+    uint256 _withdrawableAmount = _getSwapTokenAmount(msg.sender);
+
+    if (_withdrawableAmount == 0) revert Swapper_NoTokensToWithdraw();
+
+    // Delete the deposits for the user
+    delete _userDeposits[msg.sender];
+
+    // Withdraw the tokens
+    if (SWAPPED_TOKEN == address(0)) {
+      payable(msg.sender).transfer(_withdrawableAmount);
+    } else {
+      IERC20(SWAPPED_TOKEN).safeTransfer(msg.sender, _withdrawableAmount);
+    }
+
+    // Emit the event
+    emit SwappedTokensWithdrawn(msg.sender, _withdrawableAmount);
+  }
+
+  /// @inheritdoc ISwapperV2
+  function emergencyWithdraw(address token, uint256 amount) external onlyOwner {
+    if (amount == 0) revert Swapper_NoTokensToWithdraw();
+
+    if (_getTokenBalance(token) < amount) {
+      revert Swapper_NotEnoughLiquidity();
+    }
+
+    if (token == address(0)) {
+      payable(msg.sender).transfer(amount);
+    } else {
+      IERC20(token).safeTransfer(msg.sender, amount);
+    }
+    emit EmergencyWithdraw(msg.sender, token, amount);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                            Public Functions
+    //////////////////////////////////////////////////////////////*/
+
+  /// @inheritdoc ISwapperV2
+  function getSwapTokenAmount(address _user) public view returns (uint256) {
+    return _getSwapTokenAmount(_user);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                            Internal Functions
+    //////////////////////////////////////////////////////////////*/
+
+  /**
+   * @notice Gets the swap token amount for a user
+   * @param _user The address of the user
+   * @return _withdrawableAmount The amount of tokens the user is entitled to withdraw
+   */
+  function _getSwapTokenAmount(address _user) internal view returns (uint256 _withdrawableAmount) {
+    Deposits[] memory _deposits = _userDeposits[_user];
+    uint256 _totalDeposits = _deposits.length;
+
+    for (uint256 i = 0; i < _totalDeposits; i++) {
+      SwapRateInfo memory _swapRateInfo = _swaps[_deposits[i].swapIndex];
+      _withdrawableAmount += _deposits[i].amount * _swapRateInfo.totalSwapped / _swapRateInfo.totalDeposited;
+    }
+  }
+
+  /**
+   * @notice Gets the token balance of the contract
+   * @param _token The address of the token
+   * @return The balance of the token
+   */
+  function _getTokenBalance(address _token) internal view returns (uint256) {
+    if (_token == address(0)) {
+      return address(this).balance;
+    } else {
+      return IERC20(_token).balanceOf(address(this));
+    }
+  }
+
+  /**
+   * @notice Constructs the token path for the swap
+   * @return path The token path
+   */
+  function _constructTokenPath() internal view returns (address[] memory path) {
+    path = new address[](2);
+
+    if (DEPOSITED_TOKEN == address(0)) {
+      path[0] = ROUTER.WETH();
+    } else {
+      path[0] = DEPOSITED_TOKEN;
+    }
+
+    if (SWAPPED_TOKEN == address(0)) {
+      path[1] = ROUTER.WETH();
+    } else {
+      path[1] = SWAPPED_TOKEN;
+    }
+  }
+}

--- a/src/contracts/SwapperV2.sol
+++ b/src/contracts/SwapperV2.sol
@@ -127,17 +127,14 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
     Deposits[] storage _deposits = _userDeposits[msg.sender];
     uint256 _withdrawableAmount = 0;
 
-    uint256 i = 0;
-    while (i < _deposits.length) {
+    for (uint256 i = _deposits.length; i > 0;) {
+      i--;
+      // If the deposit is not yet swapped, add the amount to the withdrawable amount
       if (_deposits[i].swapIndex >= _swapIndex) {
         _withdrawableAmount += _deposits[i].amount;
-
         // Remove the element by swapping with the last and popping
         _deposits[i] = _deposits[_deposits.length - 1];
         _deposits.pop();
-        // Do not increment i since the new item at i needs to be checked
-      } else {
-          i++;
       }
     }
 
@@ -157,12 +154,35 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
   /// @inheritdoc ISwapperV2
   function withdraw() external nonReentrant {
     // Get the deposits for the user
-    uint256 _withdrawableAmount = _getSwapTokenAmount(msg.sender);
+    Deposits[] storage deposits = _userDeposits[msg.sender];
+    uint256 len = deposits.length;
+    uint256 _withdrawableAmount = 0;
+
+    // Create a temporary array in memory to hold pending (not-yet-swapped) deposits
+    Deposits[] memory pending = new Deposits[](len);
+    uint256 pendingCount = 0;
+
+    for (uint256 i = 0; i < len; i++) {
+      // If the deposit has been swapped (swapIndex < _swapIndex), add to withdrawable amount
+      if (deposits[i].swapIndex < _swapIndex) {
+        // Calculate the user's share of swapped tokens for this deposit
+        SwapRateInfo memory _swapRateInfo = _swaps[deposits[i].swapIndex];
+        _withdrawableAmount += deposits[i].amount * _swapRateInfo.totalSwapped / _swapRateInfo.totalDeposited;
+      } else {
+        // Otherwise, keep the deposit for future swaps
+        pending[pendingCount] = deposits[i];
+        pendingCount++;
+      }
+    }
+
+    // Remove all deposits for the user
+    delete _userDeposits[msg.sender];
+    // Add back only the pending (not-yet-swapped) deposits
+    for (uint256 i = 0; i < pendingCount; i++) {
+      _userDeposits[msg.sender].push(pending[i]);
+    }
 
     if (_withdrawableAmount == 0) revert Swapper_NoTokensToWithdraw();
-
-    // Delete the deposits for the user
-    delete _userDeposits[msg.sender];
 
     // Withdraw the tokens
     if (SWAPPED_TOKEN == address(0)) {

--- a/src/contracts/SwapperV2.sol
+++ b/src/contracts/SwapperV2.sol
@@ -33,9 +33,6 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
   /// @notice Mapping of user to thier deposited by swap index
   mapping(address user => Deposits[] deposits) private _userDeposits;
 
-  /// @notice Mapping of user to withdrawable balance
-  mapping(address user => uint256 amount) private _userWithdrawableBalance;
-
   /// @notice Mapping of swap index to the swap rate
   mapping(uint256 swapIndex => SwapRateInfo swapRateInfo) private _swaps;
 
@@ -84,18 +81,18 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
     address[] memory path = _constructTokenPath();
 
     uint256 _totalDeposited = _getTokenBalance(DEPOSITED_TOKEN);
-    uint256 _totalBalanceBeforeSwapping = _getTokenBalance(SWAPPED_TOKEN);
+    uint256[] memory amounts;
 
     if (DEPOSITED_TOKEN == address(0)) {
       // swapping ETH -> token
-      ROUTER.swapExactETHForTokens{value: _totalDeposited}(0, path, address(this), block.timestamp);
+      amounts = ROUTER.swapExactETHForTokens{value: _totalDeposited}(0, path, address(this), block.timestamp);
     } else {
       // Approve the router to spend the deposited tokens
       IERC20(DEPOSITED_TOKEN).approve(address(ROUTER), _totalDeposited);
 
       if (SWAPPED_TOKEN == address(0)) {
         // Swapping token -> ETH
-        ROUTER.swapExactTokensForETH(
+        amounts = ROUTER.swapExactTokensForETH(
           _totalDeposited,
           0, // Note: min amount out should be passed in as arg
           path,
@@ -104,7 +101,7 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
         );
       } else {
         // Swapping token -> token
-        ROUTER.swapExactTokensForTokens(
+        amounts = ROUTER.swapExactTokensForTokens(
           _totalDeposited,
           0, // Note: min amount out should be passed in as arg
           path,
@@ -114,7 +111,7 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
       }
     }
 
-    uint256 _totalSwapped = _getTokenBalance(SWAPPED_TOKEN) - _totalBalanceBeforeSwapping;
+    uint256 _totalSwapped = amounts[1];
 
     // Store the swap rate information
     _swaps[_swapIndex] = SwapRateInfo({totalDeposited: _totalDeposited, totalSwapped: _totalSwapped});
@@ -195,6 +192,21 @@ contract SwapperV2 is ISwapperV2, Ownable, ReentrancyGuard {
   /// @inheritdoc ISwapperV2
   function getSwapTokenAmount(address _user) public view returns (uint256) {
     return _getSwapTokenAmount(_user);
+  }
+
+  /// @inheritdoc ISwapperV2
+  function getSwapIndex() public view returns (uint256) {
+    return _swapIndex;
+  }
+
+  /// @inheritdoc ISwapperV2
+  function getSwapRateInfo(uint256 _index) public view returns (SwapRateInfo memory) {
+    return _swaps[_index];
+  }
+
+  /// @inheritdoc ISwapperV2
+  function getDeposits(address _user) public view returns (Deposits[] memory) {
+    return _userDeposits[_user];
   }
 
   /*///////////////////////////////////////////////////////////////

--- a/src/interfaces/ISwapperV2.sol
+++ b/src/interfaces/ISwapperV2.sol
@@ -6,17 +6,26 @@ pragma solidity ^0.8.23;
  * @author thelostone-mc
  * @notice Simple swapper contract to pool, swap and withdraw tokens
  */
-interface ISwapper {
-  /*///////////////////////////////////////////////////////////////
-                            Structs
-  //////////////////////////////////////////////////////////////*/
+interface ISwapperV2 {
 
-  /// @notice Struct of user
-  struct SwapInfo {
-    /// @notice Amount of tokens deposited
-    uint256 depositTokenAmount;
-    /// @notice Has the user withdrawn their tokens
-    bool hasWithdrawn;
+  /**
+   * @notice Struct to track deposit information
+   * @param amount The amount of tokens deposited
+   * @param swapIndex The index of the swap this deposit is for
+   */
+  struct Deposits {
+    uint256 amount;
+    uint256 swapIndex;
+  }
+
+  /**
+   * @notice Struct to track swap rate information
+   * @param totalDeposited The total amount of tokens deposited
+   * @param totalSwapped The total amount of tokens swapped
+   */
+  struct SwapRateInfo {
+    uint256 totalDeposited;
+    uint256 totalSwapped;
   }
 
   /*///////////////////////////////////////////////////////////////
@@ -115,15 +124,6 @@ interface ISwapper {
    */
   function SWAPPED_TOKEN() external view returns (address);
 
-  /**
-   * @notice Whether the swap has been executed
-   */
-  function swapped() external view returns (bool);
-
-  /**
-   * @notice The mapping of user to swap info
-   */
-  function userToSwapInfo(address _user) external view returns (SwapInfo memory);
 
   /*///////////////////////////////////////////////////////////////
                             Logic

--- a/src/interfaces/ISwapperV2.sol
+++ b/src/interfaces/ISwapperV2.sol
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {IUniswapV2Router02} from '@uniswap/v2-periphery/interfaces/IUniswapV2Router02.sol';
+
 /**
  * @title Swapper Contract
  * @author thelostone-mc
  * @notice Simple swapper contract to pool, swap and withdraw tokens
  */
 interface ISwapperV2 {
-
   /**
    * @notice Struct to track deposit information
    * @param amount The amount of tokens deposited
@@ -124,6 +125,15 @@ interface ISwapperV2 {
    */
   function SWAPPED_TOKEN() external view returns (address);
 
+  /**
+   * @notice The router to be used for swapping
+   */
+  function ROUTER() external view returns (IUniswapV2Router02);
+
+  /**
+   * @notice The index of the current swap
+   */
+  function getSwapIndex() external view returns (uint256);
 
   /*///////////////////////////////////////////////////////////////
                             Logic
@@ -156,6 +166,20 @@ interface ISwapperV2 {
    * @return The amount of tokens the user is entitled to
    */
   function getSwapTokenAmount(address _user) external view returns (uint256);
+
+  /**
+   * @notice The swap rate info for a given swap index
+   * @param _index The index of the swap
+   * @return The swap rate info
+   */
+  function getSwapRateInfo(uint256 _index) external view returns (SwapRateInfo memory);
+
+  /**
+   * @notice The deposits for a given user
+   * @param _user The address of the user
+   * @return The deposits
+   */
+  function getDeposits(address _user) external view returns (Deposits[] memory);
 
   /**
    * @notice Emergency withdraw function to withdraw tokens from the contract

--- a/test/integration/IntegrationBase.sol
+++ b/test/integration/IntegrationBase.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {IUniswapV2Router02} from '@uniswap/v2-periphery/interfaces/IUniswapV2Router02.sol';
 import {ISwapper, SwapperV1} from 'contracts/SwapperV1.sol';
+import {ISwapperV2, SwapperV2} from 'contracts/SwapperV2.sol';
+
 import {Test} from 'forge-std/Test.sol';
 import {IERC20} from 'forge-std/interfaces/IERC20.sol';
 
@@ -16,11 +19,24 @@ contract IntegrationBase is Test {
   address internal _bob = 0xFd546293a729fE1A05D249Ad4F2CA984082F889e;
   address internal _alice = 0xc08a8a9f809107c5A7Be6d90e315e4012c99F39a;
 
+  // Uniswap Router
+  address internal _uniswapV2Router = 0x7a250d5630B4cF539739dF2C5dAcb4c659F2488D;
+  IUniswapV2Router02 internal _router = IUniswapV2Router02(_uniswapV2Router);
+
+  // Contracts
   ISwapper internal _swapper;
+
+  ISwapperV2 internal _swapperV2;
 
   function setUp() public {
     vm.createSelectFork(vm.rpcUrl('mainnet'), _FORK_BLOCK);
-    vm.prank(_owner);
+   
+    vm.startPrank(_owner);
+    // Swapper V1
     _swapper = new SwapperV1(address(_dai), address(0));
+
+    // Swapper V2
+    _swapperV2 = new SwapperV2(address(0), address(_dai), address(_router));
+    vm.stopPrank();
   }
 }

--- a/test/integration/SwapperV2.t.sol
+++ b/test/integration/SwapperV2.t.sol
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IERC20} from '@openzeppelin/token/ERC20/IERC20.sol';
+import {ISwapperV2} from 'contracts/SwapperV2.sol';
+import {IntegrationBase} from 'test/integration/IntegrationBase.sol';
+
+contract IntegrationSwapperV2 is IntegrationBase {
+  function test_DepositSwapDepositWithdraws_ETHtoDAI() public {
+    // Bob deposits 1 ether before swap
+    vm.deal(_bob, 1 ether);
+    vm.prank(_bob);
+    _swapperV2.deposit{value: 1 ether}(1 ether);
+
+    // Owner performs swap (ETH -> DAI)
+    vm.prank(_owner);
+    _swapperV2.swap();
+
+    // Bob deposits another 1 ether after swap
+    vm.deal(_bob, 1 ether);
+    vm.prank(_bob);
+    _swapperV2.deposit{value: 1 ether}(1 ether);
+
+    // Bob tries to withdraw deposit (should only withdraw the second deposit, as the first was swapped)
+    vm.startPrank(_bob);
+    uint256 bobEthBefore = _bob.balance;
+    _swapperV2.withdrawDeposit();
+    uint256 bobEthAfter = _bob.balance;
+    vm.stopPrank();
+
+    // Bob should have received 1 ether back (the second deposit)
+    assertEq(bobEthAfter - bobEthBefore, 1 ether);
+
+    // Bob tries to withdraw swapped tokens (should only be able to withdraw the first deposit's share in DAI)
+    IERC20 dai = IERC20(_swapperV2.SWAPPED_TOKEN());
+    uint256 bobDaiBefore = dai.balanceOf(_bob);
+
+    vm.startPrank(_bob);
+    _swapperV2.withdraw();
+    vm.stopPrank();
+
+    uint256 bobDaiAfter = dai.balanceOf(_bob);
+
+    // Bob should have received some DAI (from the first deposit)
+    assertGt(bobDaiAfter - bobDaiBefore, 0);
+
+    // Check that Bob's deposits are now empty
+    ISwapperV2.Deposits[] memory deposits = _swapperV2.getDeposits(_bob);
+    assertEq(deposits.length, 0);
+  }
+}

--- a/test/invariants/fuzz/properties/Swapper.t.sol
+++ b/test/invariants/fuzz/properties/Swapper.t.sol
@@ -5,10 +5,10 @@ import {SwapperSetup} from '../setup/Swapper.t.sol';
 
 contract SwapperProperties is SwapperSetup {
   function property_swapperIsInitialized() external view {
-    assert(address(_Erc20ToErc20targetContract.DEPOSITED_TOKEN()) != address(0));
-    assert(address(_Erc20ToErc20targetContract.SWAPPED_TOKEN()) != address(0));
+    assert(address(_erc20ToErc20TargetContract.DEPOSITED_TOKEN()) != address(0));
+    assert(address(_erc20ToErc20TargetContract.SWAPPED_TOKEN()) != address(0));
 
-    assert(address(_Erc20ToNativeTargetContract.DEPOSITED_TOKEN()) != address(0));
-    assert(address(_Erc20ToNativeTargetContract.SWAPPED_TOKEN()) == address(0));
+    assert(address(_erc20ToNativeTargetContract.DEPOSITED_TOKEN()) != address(0));
+    assert(address(_erc20ToNativeTargetContract.SWAPPED_TOKEN()) == address(0));
   }
 }

--- a/test/invariants/fuzz/setup/Swapper.t.sol
+++ b/test/invariants/fuzz/setup/Swapper.t.sol
@@ -7,8 +7,8 @@ import {CommonBase} from 'forge-std/Base.sol';
 import {MockERC20} from 'test/mocks/MockERC20.sol';
 
 contract SwapperSetup is CommonBase {
-  SwapperV1 internal _Erc20ToErc20targetContract;
-  SwapperV1 internal _Erc20ToNativeTargetContract;
+  SwapperV1 internal _erc20ToErc20TargetContract;
+  SwapperV1 internal _erc20ToNativeTargetContract;
   MockERC20 internal _wunder;
   MockERC20 internal _kinder;
 
@@ -18,7 +18,7 @@ contract SwapperSetup is CommonBase {
     _kinder = new MockERC20();
     _kinder.initialize('KINDER', 'KIN', 18);
 
-    _Erc20ToErc20targetContract = new SwapperV1(address(_wunder), address(_kinder));
-    _Erc20ToNativeTargetContract = new SwapperV1(address(_wunder), address(0));
+    _erc20ToErc20TargetContract = new SwapperV1(address(_wunder), address(_kinder));
+    _erc20ToNativeTargetContract = new SwapperV1(address(_wunder), address(0));
   }
 }

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -7,4 +7,8 @@ contract MockERC20 is ForgeMockERC20 {
   function mint(address to, uint256 amount) external {
     _mint(to, amount);
   }
+
+  function burnFrom(address from, uint256 amount) external {
+    _burn(from, amount);
+  }
 }

--- a/test/mocks/MockUniswapV2Router02.sol
+++ b/test/mocks/MockUniswapV2Router02.sol
@@ -1,0 +1,249 @@
+// solhint-disable
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.23;
+
+import {IUniswapV2Router02} from '@uniswap/v2-periphery/interfaces/IUniswapV2Router02.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+contract MockUniswapV2Router02 is IUniswapV2Router02 {
+  function WETH() external pure override returns (address) {
+    return 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+  }
+
+  function swapExactETHForTokens(
+    uint256, /*amountOutMin*/
+    address[] calldata path,
+    address to,
+    uint256 /*deadline*/
+  ) external payable override returns (uint256[] memory amounts) {
+    amounts = new uint256[](2);
+    amounts[0] = msg.value;
+    amounts[1] = msg.value * 2; // 1:2 ratio
+    // Mint output tokens to recipient
+    MockERC20 outputToken = MockERC20(path[path.length - 1]);
+    outputToken.mint(to, amounts[1]);
+  }
+
+  function swapTokensForExactETH(
+    uint /*amountOut*/,
+    uint amountInMax,
+    address[] calldata /*path*/,
+    address /*to*/,
+    uint /*deadline*/
+  ) external pure override returns (uint[] memory amounts) {
+    amounts = new uint[](2);
+    amounts[0] = amountInMax;
+    amounts[1] = amountInMax / 2; // 2:1 ratio (output is half the input)
+  }
+
+  function swapTokensForExactTokens(
+    uint256, /*amountOut*/
+    uint256, /*amountInMax*/
+    address[] calldata, /*path*/
+    address, /*to*/
+    uint256 /*deadline*/
+  ) external pure override returns (uint256[] memory) {
+    revert();
+  }
+
+  function swapETHForExactTokens(
+    uint256, /*amountOut*/
+    address[] calldata, /*path*/
+    address, /*to*/
+    uint256 /*deadline*/
+  ) external payable override returns (uint256[] memory) {
+    revert();
+  }
+
+  function swapExactTokensForETH(
+    uint amountIn,
+    uint /*amountOutMin*/,
+    address[] calldata path,
+    address /*to*/,
+    uint /*deadline*/
+  ) external override returns (uint[] memory amounts) {
+    amounts = new uint[](2);
+    amounts[0] = amountIn;
+    amounts[1] = amountIn / 2; // 2:1 ratio (output is half the input)
+    // Burn input tokens from the Swapper contract
+    MockERC20 inputToken = MockERC20(path[0]);
+    inputToken.burnFrom(msg.sender, amountIn);
+  }
+
+  function swapExactTokensForTokens(
+    uint256 amountIn,
+    uint256, /*amountOutMin*/
+    address[] calldata path,
+    address to,
+    uint256 /*deadline*/
+  ) external override returns (uint256[] memory amounts) {
+    amounts = new uint256[](2);
+    amounts[0] = amountIn;
+    amounts[1] = amountIn * 4; // 1:4 ratio
+    // Mint output tokens to recipient
+    MockERC20 outputToken = MockERC20(path[path.length - 1]);
+    outputToken.mint(to, amounts[1]);
+
+    // Burn input tokens from the Swapper contract
+    MockERC20 inputToken = MockERC20(path[0]);
+    inputToken.burnFrom(msg.sender, amountIn);
+  }
+
+  // The following are required by the interface but not used in your tests. They can revert or return dummy values.
+  function factory() external pure override returns (address) {
+    revert();
+  }
+
+  function addLiquidity(
+    address,
+    address,
+    uint256,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256
+  ) external pure override returns (uint256, uint256, uint256) {
+    revert();
+  }
+
+  function addLiquidityETH(
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256
+  ) external payable override returns (uint256, uint256, uint256) {
+    revert();
+  }
+
+  function removeLiquidity(
+    address,
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256
+  ) external pure override returns (uint256, uint256) {
+    revert();
+  }
+
+  function removeLiquidityETH(
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256
+  ) external pure override returns (uint256, uint256) {
+    revert();
+  }
+
+  function removeLiquidityWithPermit(
+    address,
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256,
+    bool,
+    uint8,
+    bytes32,
+    bytes32
+  ) external pure override returns (uint256, uint256) {
+    revert();
+  }
+
+  function removeLiquidityETHWithPermit(
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256,
+    bool,
+    uint8,
+    bytes32,
+    bytes32
+  ) external pure override returns (uint256, uint256) {
+    revert();
+  }
+
+  function quote(uint256, uint256, uint256) external pure override returns (uint256) {
+    revert();
+  }
+
+  function getAmountOut(uint256, uint256, uint256) external pure override returns (uint256) {
+    revert();
+  }
+
+  function getAmountIn(uint256, uint256, uint256) external pure override returns (uint256) {
+    revert();
+  }
+
+  function getAmountsOut(uint256, address[] calldata) external pure override returns (uint256[] memory) {
+    revert();
+  }
+
+  function getAmountsIn(uint256, address[] calldata) external pure override returns (uint256[] memory) {
+    revert();
+  }
+
+  function removeLiquidityETHSupportingFeeOnTransferTokens(
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256
+  ) external pure override returns (uint256) {
+    revert();
+  }
+
+  function removeLiquidityETHWithPermitSupportingFeeOnTransferTokens(
+    address,
+    uint256,
+    uint256,
+    uint256,
+    address,
+    uint256,
+    bool,
+    uint8,
+    bytes32,
+    bytes32
+  ) external pure override returns (uint256) {
+    revert();
+  }
+
+  function swapExactTokensForTokensSupportingFeeOnTransferTokens(
+    uint256,
+    uint256,
+    address[] calldata,
+    address,
+    uint256
+  ) external pure override {
+    revert();
+  }
+
+  function swapExactETHForTokensSupportingFeeOnTransferTokens(
+    uint256,
+    address[] calldata,
+    address,
+    uint256
+  ) external payable override {
+    revert();
+  }
+
+  function swapExactTokensForETHSupportingFeeOnTransferTokens(
+    uint256,
+    uint256,
+    address[] calldata,
+    address,
+    uint256
+  ) external pure override {
+    revert();
+  }
+}

--- a/test/unit/SwapperV1.t.sol
+++ b/test/unit/SwapperV1.t.sol
@@ -21,7 +21,6 @@ contract UnitSwapperV1 is Test {
   address internal _owner = makeAddr('_owner');
   address internal _bob = makeAddr('_bob');
   address internal _alice = makeAddr('_alice');
-  address internal _whale = makeAddr('_whale');
 
   function setUp() public {
     vm.startPrank(_owner);

--- a/test/unit/SwapperV1.t.sol
+++ b/test/unit/SwapperV1.t.sol
@@ -51,7 +51,7 @@ contract UnitSwapperV1 is Test {
 
   function test_ConstructorWhenPassingSameTokenForDepositedAndSwapped() public {
     // it reverts
-    vm.expectRevert(ISwapper.SwapperV1_InvalidTokens.selector);
+    vm.expectRevert(ISwapper.Swapper_InvalidTokens.selector);
     new SwapperV1(address(wunder), address(wunder));
   }
 
@@ -106,7 +106,7 @@ contract UnitSwapperV1 is Test {
   }
 
   function test_DepositWhenPassingAmountOf0() public {
-    vm.expectRevert(ISwapper.SwapperV1_InvalidAmount.selector);
+    vm.expectRevert(ISwapper.Swapper_InvalidAmount.selector);
     vm.prank(_bob);
     // it reverts
     nativeToERC20Swapper.deposit{value: 0}(0);
@@ -115,14 +115,14 @@ contract UnitSwapperV1 is Test {
   function test_DepositWhenBalanceOfTheContractIsLessThanTheAmountSent() public {
     vm.deal(_bob, 1 ether);
 
-    vm.expectRevert(ISwapper.SwapperV1_AmountMismatch.selector);
+    vm.expectRevert(ISwapper.Swapper_AmountMismatch.selector);
     vm.prank(_bob);
     nativeToERC20Swapper.deposit{value: 0.5 ether}(1e18);
   }
 
   function test_DepositWhenBalanceOfTheContractIsGreaterThanTheAmountSent() public {
     vm.deal(_bob, 1 ether);
-    vm.expectRevert(ISwapper.SwapperV1_AmountMismatch.selector);
+    vm.expectRevert(ISwapper.Swapper_AmountMismatch.selector);
 
     vm.prank(_bob);
     nativeToERC20Swapper.deposit{value: 1 ether}(0.5 ether);
@@ -151,7 +151,7 @@ contract UnitSwapperV1 is Test {
     test_SwapWhenSwappingToERC20TokensToTheContract();
 
     vm.deal(_bob, 1 ether);
-    vm.expectRevert(ISwapper.SwapperV1_SwapAlreadyExecuted.selector);
+    vm.expectRevert(ISwapper.Swapper_SwapAlreadyExecuted.selector);
     vm.prank(_bob);
     // it reverts
     nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
@@ -220,7 +220,7 @@ contract UnitSwapperV1 is Test {
 
   function test_SwapWhenPassingAmountOf0() public {
     test_DepositWhenPassingValidErc20TokenAmount();
-    vm.expectRevert(ISwapper.SwapperV1_NotEnoughLiquidity.selector);
+    vm.expectRevert(ISwapper.Swapper_NotEnoughLiquidity.selector);
     vm.deal(_owner, 1 ether);
     vm.prank(_owner);
     // it reverts
@@ -229,7 +229,7 @@ contract UnitSwapperV1 is Test {
 
   function test_SwapWhenCalledAfterSwap() public {
     test_SwapWhenSwappingToERC20TokensToTheContract();
-    vm.expectRevert(ISwapper.SwapperV1_SwapAlreadyExecuted.selector);
+    vm.expectRevert(ISwapper.Swapper_SwapAlreadyExecuted.selector);
     vm.prank(_owner);
     // it reverts
     nativeToERC20Swapper.swap();
@@ -286,7 +286,7 @@ contract UnitSwapperV1 is Test {
   function test_WithdrawWhenNoTokensToWithdraw() public {
     test_SwapWhenSwappingToERC20TokensToTheContract();
 
-    vm.expectRevert(ISwapper.SwapperV1_NoTokensToWithdraw.selector);
+    vm.expectRevert(ISwapper.Swapper_NoTokensToWithdraw.selector);
     vm.prank(makeAddr('user'));
     // it reverts
     nativeToERC20Swapper.withdraw();
@@ -297,7 +297,7 @@ contract UnitSwapperV1 is Test {
     vm.startPrank(_bob);
     erc20ToNativeSwapper.withdraw();
 
-    vm.expectRevert(ISwapper.SwapperV1_AlreadyWithdrawn.selector);
+    vm.expectRevert(ISwapper.Swapper_AlreadyWithdrawn.selector);
     // it reverts
     erc20ToNativeSwapper.withdraw();
 
@@ -306,7 +306,7 @@ contract UnitSwapperV1 is Test {
 
   function test_WithdrawWhenCalledBeforeSwap() public {
     test_DepositWhenPassingValidNativeTokenAmount();
-    vm.expectRevert(ISwapper.SwapperV1_SwapNotExecuted.selector);
+    vm.expectRevert(ISwapper.Swapper_SwapNotExecuted.selector);
     vm.prank(_bob);
     // it reverts
     nativeToERC20Swapper.withdraw();
@@ -333,7 +333,7 @@ contract UnitSwapperV1 is Test {
   }
 
   function test_WithdrawDepositWhenNoTokensToWithdraw() public {
-    vm.expectRevert(ISwapper.SwapperV1_NoTokensToWithdraw.selector);
+    vm.expectRevert(ISwapper.Swapper_NoTokensToWithdraw.selector);
     vm.prank(_bob);
     // it reverts
     nativeToERC20Swapper.withdrawDeposit();
@@ -341,7 +341,7 @@ contract UnitSwapperV1 is Test {
 
   function test_WithdrawDepositWhenCalledAfterSwap() public {
     test_SwapWhenSwappingToERC20TokensToTheContract();
-    vm.expectRevert(ISwapper.SwapperV1_SwapAlreadyExecuted.selector);
+    vm.expectRevert(ISwapper.Swapper_SwapAlreadyExecuted.selector);
     vm.prank(_bob);
     // it reverts
     nativeToERC20Swapper.withdrawDeposit();
@@ -364,7 +364,7 @@ contract UnitSwapperV1 is Test {
   }
 
   function test_EmergencyWithdrawWhenPassingAmountOf0() public {
-    vm.expectRevert(ISwapper.SwapperV1_NoTokensToWithdraw.selector);
+    vm.expectRevert(ISwapper.Swapper_NoTokensToWithdraw.selector);
     vm.prank(_owner);
     // it reverts
     nativeToERC20Swapper.emergencyWithdraw(address(0), 0);
@@ -379,7 +379,7 @@ contract UnitSwapperV1 is Test {
 
   function test_EmergencyWithdrawWhenPassingAmountGreaterThanTheBalance() public {
     vm.deal(address(nativeToERC20Swapper), 1 ether);
-    vm.expectRevert(ISwapper.SwapperV1_NotEnoughLiquidity.selector);
+    vm.expectRevert(ISwapper.Swapper_NotEnoughLiquidity.selector);
     vm.prank(_owner);
     // it reverts
     nativeToERC20Swapper.emergencyWithdraw(address(0), 2 ether);

--- a/test/unit/SwapperV2.t.sol
+++ b/test/unit/SwapperV2.t.sol
@@ -1,0 +1,346 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity 0.8.23;
+
+import {Ownable} from '@openzeppelin/access/Ownable.sol';
+import {IUniswapV2Router02} from 'node_modules/@uniswap/v2-periphery/contracts/interfaces/IUniswapV2Router02.sol';
+
+import {Test} from 'forge-std/Test.sol';
+import {ISwapperV2, SwapperV2} from 'src/contracts/SwapperV2.sol';
+import {MockERC20} from 'test/mocks/MockERC20.sol';
+
+contract UnitSwapperV2 is Test {
+  SwapperV2 public nativeToERC20Swapper;
+  SwapperV2 public erc20ToNativeSwapper;
+  SwapperV2 public erc20ToErc20Swapper;
+
+  address internal _mockRouter = makeAddr('_router');
+
+  MockERC20 public wunder;
+  MockERC20 public kinder;
+
+  address internal _owner = makeAddr('_owner');
+  address internal _bob = makeAddr('_bob');
+  address internal _alice = makeAddr('_alice');
+
+  function setUp() public {
+    vm.startPrank(_owner);
+
+    // Setup ERC20 tokens
+    wunder = new MockERC20();
+    wunder.initialize('WUNDER', 'WUN', 8);
+    kinder = new MockERC20();
+    kinder.initialize('KINDER', 'KIN', 8);
+
+    // Setup Swapper Contracts
+    nativeToERC20Swapper = new SwapperV2(address(0), address(wunder), address(_mockRouter));
+    erc20ToNativeSwapper = new SwapperV2(address(wunder), address(0), address(_mockRouter));
+    erc20ToErc20Swapper = new SwapperV2(address(wunder), address(kinder), address(_mockRouter));
+
+    vm.stopPrank();
+  }
+
+  function test_ConstructorWhenPassingValidTokens() external view {
+    // it deploys
+    assertEq(nativeToERC20Swapper.owner(), _owner);
+    // it sets the deposited token
+    assertEq(nativeToERC20Swapper.DEPOSITED_TOKEN(), address(0));
+    // it sets the swapped token
+    assertEq(nativeToERC20Swapper.SWAPPED_TOKEN(), address(wunder));
+    // it sets the router
+    assertEq(address(nativeToERC20Swapper.ROUTER()), address(_mockRouter));
+  }
+
+  function test_ConstructorWhenPassingSameTokenForDepositedAndSwapped() external {
+    vm.expectRevert(ISwapperV2.Swapper_InvalidTokens.selector);
+    new SwapperV2(address(wunder), address(wunder), address(_mockRouter));
+  }
+
+  function test_DepositWhenPassingValidNativeTokenAmount() public {
+    vm.deal(_bob, 1 ether);
+    // it emits TokensDeposited
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.TokensDeposited(_bob, 1 ether);
+
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
+
+    // it deposits the amount to the contract
+    assertEq(address(_bob).balance, 0);
+    assertEq(address(nativeToERC20Swapper).balance, 1 ether);
+
+    // it appends a deposit entry for the user
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 1);
+    assertEq(deposits[0].amount, 1 ether);
+    assertEq(deposits[0].swapIndex, 0);
+  }
+
+  function test_DepositWhenPassingValidERC20TokenAmount() external {
+    wunder.mint(_bob, 1e8);
+
+    vm.startPrank(_bob);
+
+    wunder.approve(address(erc20ToNativeSwapper), 1e8);
+
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.TokensDeposited(_bob, 1e8);
+
+    erc20ToNativeSwapper.deposit(1e8);
+
+    // it deposits the amount to the contract
+    assertEq(wunder.balanceOf(address(erc20ToNativeSwapper)), 1e8);
+    assertEq(wunder.balanceOf(address(_bob)), 0);
+
+    // it appends a deposit entry for the user
+    ISwapperV2.Deposits[] memory deposits = erc20ToNativeSwapper.getDeposits(_bob);
+    assertEq(deposits.length, 1);
+    assertEq(deposits[0].amount, 1e8);
+    assertEq(deposits[0].swapIndex, 0);
+  }
+
+  function test_DepositWhenDepositingMoreThanOnce() external {
+    test_DepositWhenPassingValidNativeTokenAmount();
+
+    vm.deal(_bob, 1 ether);
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
+
+    // it appends multiple deposit entries for the user
+    // it updates the balance of the contract
+    assertEq(address(nativeToERC20Swapper).balance, 2 ether);
+
+    // it appends multiple deposit entries for the user
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 2);
+    assertEq(deposits[0].amount, 1 ether);
+    assertEq(deposits[0].swapIndex, 0);
+    assertEq(deposits[1].amount, 1 ether);
+    assertEq(deposits[1].swapIndex, 0);
+  }
+
+  function test_DepositWhenPassingAmountOf0() external {
+    vm.expectRevert(ISwapperV2.Swapper_InvalidAmount.selector);
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.deposit{value: 0}(0);
+  }
+
+  function test_DepositWhenBalanceOfTheContractIsLessThanTheAmountSent() external {
+    vm.deal(_bob, 1 ether);
+
+    vm.expectRevert(ISwapperV2.Swapper_AmountMismatch.selector);
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.deposit{value: 0.5 ether}(1e18);
+  }
+
+  function test_DepositWhenBalanceOfTheContractIsGreaterThanTheAmountSent() external {
+    vm.deal(_bob, 1 ether);
+    vm.expectRevert(ISwapperV2.Swapper_AmountMismatch.selector);
+
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.deposit{value: 1 ether}(0.5 ether);
+  }
+
+  function test_WithdrawDepositWhenWithdrawingBeforeAnySwap() external {
+    test_DepositWhenPassingValidNativeTokenAmount();
+
+    vm.startPrank(_bob);
+
+    // it emits DepositWithdrawn
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.DepositWithdrawn(address(_bob), 1 ether);
+    nativeToERC20Swapper.withdrawDeposit();
+
+    vm.stopPrank();
+
+    // it returns the deposit token amount to the user
+    assertEq(address(_bob).balance, 1 ether);
+    assertEq(address(nativeToERC20Swapper).balance, 0);
+    // it deletes the user's deposit entries
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 0);
+  }
+
+  function test_WithdrawDepositWhenNoTokensToWithdraw() external {
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.withdrawDeposit();
+  }
+
+  function test_WithdrawDepositWhenCalledAfterSwapForDepositsAlreadySwapped() external {
+    // it does not withdraw swapped deposits (only pre-swap deposits)
+  }
+
+  function test_WithdrawDepositWhenUserHasBothPre_swapAndPost_swapDeposits() external {
+    // it only withdraws pre-swap deposits
+    // it leaves post-swap deposits for future swaps
+  }
+
+  // function test_SwapWhenSwappingNativeToERC20TokensToTheContract() external {
+  //   test_DepositWhenPassingValidNativeTokenAmount();
+  //   assertEq(nativeToERC20Swapper.getSwapIndex(), 0);
+
+  //   vm.mockCall{value: 1e18}(
+  //     address(_mockRouter),
+  //     abi.encodeWithSelector(
+  //       IUniswapV2Router02.swapExactETHForTokens.selector,
+  //       0,
+  //       _constructTokenPath(address(0), address(wunder)),
+  //       address(nativeToERC20Swapper),
+  //       block.timestamp
+  //     ),
+  //     abi.encode([1 ether, 1e18])
+  //   );
+
+  //   vm.startPrank(_owner);
+
+  //   // TODO: How do i transfer wunder to the contract ?
+
+  //   // it emits TokensSwapped
+  //   // vm.expectEmit(true, true, true, true);
+  //   // emit ISwapper.TokensSwapped(1e18, 1e18);
+
+  //   nativeToERC20Swapper.swap();
+  //   vm.stopPrank();
+
+  //   vm.expectCall(
+  //     address(_mockRouter),
+  //     abi.encodeWithSelector(
+  //       IUniswapV2Router02.swapExactETHForTokens.selector,
+  //       0,
+  //       _constructTokenPath(address(0), address(wunder)),
+  //       address(nativeToERC20Swapper),
+  //       block.timestamp
+  //     )
+  //   );
+
+  //   // it swaps via Uniswap V2 router
+  //   // it records the swap rate for the round
+  //   SwapperV2.SwapRateInfo memory _swapRateInfo = nativeToERC20Swapper.getSwapRateInfo(0);
+  //   assertEq(_swapRateInfo.totalDeposited, 1e18);
+  //   assertEq(_swapRateInfo.totalSwapped, 1e18);
+
+  //   // it increments the swap index
+  //   assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
+  // }
+
+  function test_SwapWhenSwappingERC20ToNativeTokenToTheContract() external {
+    // it swaps via Uniswap V2 router
+    // it records the swap rate for the round
+    // it increments the swap index
+    // it emits TokensSwapped
+  }
+
+  function test_SwapWhenSwappingERC20ToERC20TokensToTheContract() external {
+    // it swaps via Uniswap V2 router
+    // it records the swap rate for the round
+    // it increments the swap index
+    // it emits TokensSwapped
+  }
+
+  function test_SwapWhenCalledByANon_owner() external {
+    // it reverts
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _bob));
+    vm.prank(_bob);
+    nativeToERC20Swapper.swap();
+  }
+
+  function test_WithdrawWhenWithdrawingAfterASwap() external {
+    // it transfers the correct share of swapped tokens to the user
+    // it deletes the user's deposit entries for swapped rounds
+    // it emits SwappedTokensWithdrawn
+  }
+
+  function test_WithdrawWhenUserHasDepositsFromMultipleRounds() external {
+    // it calculates and transfers the sum of all eligible swapped tokens
+    // it deletes all user's deposit entries
+  }
+
+  function test_WithdrawWhenNoTokensToWithdraw() external {
+    // it reverts
+  }
+
+  function test_WithdrawWhenCalledBeforeAnySwap() external {
+    // it reverts or returns 0
+  }
+
+  function test_GetSwapTokenAmountWhenCalledAfterASwap() external {
+    // it returns the correct withdrawable amount for the user
+    // it returns 0 if user has no deposits
+  }
+
+  function test_GetSwapTokenAmountWhenCalledBeforeAnySwap() external {
+    // it returns 0
+  }
+
+  function test_EmergencyWithdrawWhenWithdrawing() external {
+    // deal the contract with 1 ether
+    vm.deal(address(nativeToERC20Swapper), 1 ether);
+
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.EmergencyWithdraw(_owner, address(0), 1 ether);
+
+    vm.prank(_owner);
+    // it emits EmergencyWithdraw
+    nativeToERC20Swapper.emergencyWithdraw(address(0), 1 ether);
+
+    // it transfers the tokens to the user
+    assertEq(address(nativeToERC20Swapper).balance, 0);
+    assertEq(_owner.balance, 1 ether);
+  }
+
+  function test_EmergencyWithdrawWhenPassingAmountOf0() external {
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_owner);
+    // it reverts
+    nativeToERC20Swapper.emergencyWithdraw(address(0), 0);
+  }
+
+  function test_EmergencyWithdrawWhenCalledByANon_owner() external {
+    vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, _bob));
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.emergencyWithdraw(address(0), 1 ether);
+  }
+
+  function test_EmergencyWithdrawWhenPassingAmountGreaterThanTheBalance() external {
+    vm.deal(address(nativeToERC20Swapper), 1 ether);
+    vm.expectRevert(ISwapperV2.Swapper_NotEnoughLiquidity.selector);
+    vm.prank(_owner);
+    // it reverts
+    nativeToERC20Swapper.emergencyWithdraw(address(0), 2 ether);
+  }
+
+  function test_SwapWhenUsersDepositsAndSwapsAndWithdrawsAndDepositsAgain() external {
+    // it tracks deposits and swaps per round
+    // it allows users to participate in multiple rounds
+    // it calculates correct withdrawable amounts for each round
+  }
+
+  function test_SwapWhenSomeUsersWithdrawBeforeSwapAndOthersAfter() external {
+    // it only includes active deposits in the swap
+    // it does not double-count or lose user funds
+  }
+
+  function _constructTokenPath(
+    address _depositedToken,
+    address _swappedToken
+  ) internal view returns (address[] memory path) {
+    path = new address[](2);
+
+    if (_depositedToken == address(0)) {
+      path[0] = IUniswapV2Router02(_mockRouter).WETH();
+    } else {
+      path[0] = _depositedToken;
+    }
+
+    if (_swappedToken == address(0)) {
+      path[1] = IUniswapV2Router02(_mockRouter).WETH();
+    } else {
+      path[1] = _swappedToken;
+    }
+  }
+}

--- a/test/unit/SwapperV2.t.sol
+++ b/test/unit/SwapperV2.t.sol
@@ -7,13 +7,14 @@ import {IUniswapV2Router02} from 'node_modules/@uniswap/v2-periphery/contracts/i
 import {Test} from 'forge-std/Test.sol';
 import {ISwapperV2, SwapperV2} from 'src/contracts/SwapperV2.sol';
 import {MockERC20} from 'test/mocks/MockERC20.sol';
+import {MockUniswapV2Router02} from 'test/mocks/MockUniswapV2Router02.sol';
 
 contract UnitSwapperV2 is Test {
   SwapperV2 public nativeToERC20Swapper;
   SwapperV2 public erc20ToNativeSwapper;
   SwapperV2 public erc20ToErc20Swapper;
 
-  address internal _mockRouter = makeAddr('_router');
+  MockUniswapV2Router02 internal _mockRouter;
 
   MockERC20 public wunder;
   MockERC20 public kinder;
@@ -21,15 +22,18 @@ contract UnitSwapperV2 is Test {
   address internal _owner = makeAddr('_owner');
   address internal _bob = makeAddr('_bob');
   address internal _alice = makeAddr('_alice');
+  address internal _weth = makeAddr('weth');
 
   function setUp() public {
     vm.startPrank(_owner);
 
     // Setup ERC20 tokens
     wunder = new MockERC20();
-    wunder.initialize('WUNDER', 'WUN', 8);
+    wunder.initialize('WUNDER', 'WUN', 18);
     kinder = new MockERC20();
-    kinder.initialize('KINDER', 'KIN', 8);
+    kinder.initialize('KINDER', 'KIN', 18);
+
+    _mockRouter = new MockUniswapV2Router02();
 
     // Setup Swapper Contracts
     nativeToERC20Swapper = new SwapperV2(address(0), address(wunder), address(_mockRouter));
@@ -75,26 +79,26 @@ contract UnitSwapperV2 is Test {
     assertEq(deposits[0].swapIndex, 0);
   }
 
-  function test_DepositWhenPassingValidERC20TokenAmount() external {
-    wunder.mint(_bob, 1e8);
+  function test_DepositWhenPassingValidERC20TokenAmount() public {
+    wunder.mint(_bob, 1e18);
 
     vm.startPrank(_bob);
 
-    wunder.approve(address(erc20ToNativeSwapper), 1e8);
+    wunder.approve(address(erc20ToNativeSwapper), 1e18);
 
     vm.expectEmit(true, true, true, true);
-    emit ISwapperV2.TokensDeposited(_bob, 1e8);
+    emit ISwapperV2.TokensDeposited(_bob, 1e18);
 
-    erc20ToNativeSwapper.deposit(1e8);
+    erc20ToNativeSwapper.deposit(1e18);
 
     // it deposits the amount to the contract
-    assertEq(wunder.balanceOf(address(erc20ToNativeSwapper)), 1e8);
+    assertEq(wunder.balanceOf(address(erc20ToNativeSwapper)), 1e18);
     assertEq(wunder.balanceOf(address(_bob)), 0);
 
     // it appends a deposit entry for the user
     ISwapperV2.Deposits[] memory deposits = erc20ToNativeSwapper.getDeposits(_bob);
     assertEq(deposits.length, 1);
-    assertEq(deposits[0].amount, 1e8);
+    assertEq(deposits[0].amount, 1e18);
     assertEq(deposits[0].swapIndex, 0);
   }
 
@@ -171,74 +175,139 @@ contract UnitSwapperV2 is Test {
   }
 
   function test_WithdrawDepositWhenCalledAfterSwapForDepositsAlreadySwapped() external {
-    // it does not withdraw swapped deposits (only pre-swap deposits)
+    // deposit 1 eth and swap it to 2 wunder
+    test_SwapWhenSwappingNativeToERC20TokensToTheContract();
+
+    // withdraw deposit
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_bob);
+    nativeToERC20Swapper.withdrawDeposit();
+
   }
 
   function test_WithdrawDepositWhenUserHasBothPre_swapAndPost_swapDeposits() external {
-    // it only withdraws pre-swap deposits
-    // it leaves post-swap deposits for future swaps
+    // deposit 1 eth and swap it to 2 wunder
+    test_SwapWhenSwappingNativeToERC20TokensToTheContract();
+
+    // deposit 1 eth again
+    vm.deal(_bob, 1 ether);
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
+
+    ISwapperV2.Deposits[] memory deposits_before_withdraw = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits_before_withdraw.length, 2);
+
+    assertEq(address(nativeToERC20Swapper).balance, 1 ether);
+    assertEq(wunder.balanceOf(address(nativeToERC20Swapper)), 2 ether);
+
+    // withdraw deposit
+    vm.startPrank(_bob);
+
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.DepositWithdrawn(address(_bob), 1 ether);
+  
+    nativeToERC20Swapper.withdrawDeposit();
+    vm.stopPrank();
+
+    assertEq(address(nativeToERC20Swapper).balance, 0);
+    assertEq(wunder.balanceOf(address(nativeToERC20Swapper)), 2 ether);
+
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 1);
+
+    assertEq(deposits[0].amount, 1 ether);
+    assertEq(deposits[0].swapIndex, 0);
   }
 
-  // function test_SwapWhenSwappingNativeToERC20TokensToTheContract() external {
-  //   test_DepositWhenPassingValidNativeTokenAmount();
-  //   assertEq(nativeToERC20Swapper.getSwapIndex(), 0);
+  function test_SwapWhenSwappingNativeToERC20TokensToTheContract() public {
+    test_DepositWhenPassingValidNativeTokenAmount();
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 0);
 
-  //   vm.mockCall{value: 1e18}(
-  //     address(_mockRouter),
-  //     abi.encodeWithSelector(
-  //       IUniswapV2Router02.swapExactETHForTokens.selector,
-  //       0,
-  //       _constructTokenPath(address(0), address(wunder)),
-  //       address(nativeToERC20Swapper),
-  //       block.timestamp
-  //     ),
-  //     abi.encode([1 ether, 1e18])
-  //   );
+    vm.startPrank(_owner);
 
-  //   vm.startPrank(_owner);
+    // it emits TokensSwapped
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.TokensSwapped(1e18, 2e18);
 
-  //   // TODO: How do i transfer wunder to the contract ?
+    nativeToERC20Swapper.swap();
+    vm.stopPrank();
 
-  //   // it emits TokensSwapped
-  //   // vm.expectEmit(true, true, true, true);
-  //   // emit ISwapper.TokensSwapped(1e18, 1e18);
-
-  //   nativeToERC20Swapper.swap();
-  //   vm.stopPrank();
-
-  //   vm.expectCall(
-  //     address(_mockRouter),
-  //     abi.encodeWithSelector(
-  //       IUniswapV2Router02.swapExactETHForTokens.selector,
-  //       0,
-  //       _constructTokenPath(address(0), address(wunder)),
-  //       address(nativeToERC20Swapper),
-  //       block.timestamp
-  //     )
-  //   );
-
-  //   // it swaps via Uniswap V2 router
-  //   // it records the swap rate for the round
-  //   SwapperV2.SwapRateInfo memory _swapRateInfo = nativeToERC20Swapper.getSwapRateInfo(0);
-  //   assertEq(_swapRateInfo.totalDeposited, 1e18);
-  //   assertEq(_swapRateInfo.totalSwapped, 1e18);
-
-  //   // it increments the swap index
-  //   assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
-  // }
-
-  function test_SwapWhenSwappingERC20ToNativeTokenToTheContract() external {
     // it swaps via Uniswap V2 router
     // it records the swap rate for the round
+    SwapperV2.SwapRateInfo memory _swapRateInfo = nativeToERC20Swapper.getSwapRateInfo(0);
+    assertEq(_swapRateInfo.totalDeposited, 1e18);
+    assertEq(_swapRateInfo.totalSwapped, 2e18);
+
     // it increments the swap index
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
+
+    assertEq(address(nativeToERC20Swapper).balance, 0);
+
+    // The Swapper contract should now hold 2 ether worth of wunder tokens (1:2 ratio)
+    assertEq(wunder.balanceOf(address(nativeToERC20Swapper)), 2 ether);
+  }
+
+  function test_SwapWhenSwappingERC20ToNativeTokenToTheContract() public {
+    test_DepositWhenPassingValidERC20TokenAmount();
+    assertEq(erc20ToNativeSwapper.getSwapIndex(), 0);
+
+    vm.startPrank(_owner);
+
     // it emits TokensSwapped
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.TokensSwapped(1e18, 0.5 ether);
+
+    erc20ToNativeSwapper.swap();
+    vm.deal(address(erc20ToNativeSwapper), 0.5 ether);
+    
+    vm.stopPrank();
+
+    // it swaps via Uniswap V2 router
+    // it records the swap rate for the round
+    SwapperV2.SwapRateInfo memory _swapRateInfo = erc20ToNativeSwapper.getSwapRateInfo(0);
+    assertEq(_swapRateInfo.totalDeposited, 1e18);
+    assertEq(_swapRateInfo.totalSwapped, 0.5 ether);
+
+    // it increments the swap index
+    assertEq(erc20ToNativeSwapper.getSwapIndex(), 1);
+
+    assertEq(address(erc20ToNativeSwapper).balance, 0.5 ether);
+    assertEq(wunder.balanceOf(address(erc20ToNativeSwapper)), 0);
   }
 
   function test_SwapWhenSwappingERC20ToERC20TokensToTheContract() external {
+
+    // Deposit
+    wunder.mint(_bob, 1e18);
+    vm.startPrank(_bob);
+    wunder.approve(address(erc20ToErc20Swapper), 1e18);
+    erc20ToErc20Swapper.deposit(1e18);
+    vm.stopPrank();
+
+    assertEq(erc20ToErc20Swapper.getSwapIndex(), 0);
+
+    vm.startPrank(_owner);
+
+    // Swap
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.TokensSwapped(1e18, 4e18);
+
+    erc20ToErc20Swapper.swap();
+
+    vm.stopPrank();
+
     // it swaps via Uniswap V2 router
     // it records the swap rate for the round
+    SwapperV2.SwapRateInfo memory _swapRateInfo = erc20ToErc20Swapper.getSwapRateInfo(0);
+    assertEq(_swapRateInfo.totalDeposited, 1e18);
+    assertEq(_swapRateInfo.totalSwapped, 4e18);
+
     // it increments the swap index
-    // it emits TokensSwapped
+    assertEq(erc20ToErc20Swapper.getSwapIndex(), 1);
+
+    // Verify the swap was successful
+    assertEq(wunder.balanceOf(address(erc20ToErc20Swapper)), 0);
+    assertEq(kinder.balanceOf(address(erc20ToErc20Swapper)), 4 ether);
   }
 
   function test_SwapWhenCalledByANon_owner() external {
@@ -248,32 +317,88 @@ contract UnitSwapperV2 is Test {
     nativeToERC20Swapper.swap();
   }
 
-  function test_WithdrawWhenWithdrawingAfterASwap() external {
-    // it transfers the correct share of swapped tokens to the user
-    // it deletes the user's deposit entries for swapped rounds
+  function test_WithdrawWhenWithdrawingAfterASwap() public {
+
+    test_SwapWhenSwappingNativeToERC20TokensToTheContract();
+
+    assertEq(wunder.balanceOf(address(_bob)), 0);
+
+    vm.startPrank(_bob);
+
     // it emits SwappedTokensWithdrawn
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.SwappedTokensWithdrawn(address(_bob), 2 ether);
+
+    nativeToERC20Swapper.withdraw();
+
+    vm.stopPrank();
+
+    // it transfers the correct share of swapped tokens to the user
+    assertEq(wunder.balanceOf(address(_bob)), 2 ether);
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
+
+    // it deletes the user's deposit entries for swapped rounds
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 0);
   }
 
   function test_WithdrawWhenUserHasDepositsFromMultipleRounds() external {
-    // it calculates and transfers the sum of all eligible swapped tokens
-    // it deletes all user's deposit entries
+
+    test_SwapWhenSwappingNativeToERC20TokensToTheContract();
+    
+    // deposit and swap 1 ether again
+    vm.deal(_bob, 1 ether);
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
+    vm.prank(_owner);
+    nativeToERC20Swapper.swap();
+
+    assertEq(wunder.balanceOf(address(_bob)), 0);
+
+    vm.startPrank(_bob);
+
+    // it emits SwappedTokensWithdrawn
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.SwappedTokensWithdrawn(address(_bob), 4 ether);
+
+    nativeToERC20Swapper.withdraw();
+
+    vm.stopPrank();
+
+    // it transfers the correct share of swapped tokens to the user
+    assertEq(wunder.balanceOf(address(_bob)), 4 ether);
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 2);
+
+    // it deletes the user's deposit entries for swapped rounds
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 0);
   }
 
   function test_WithdrawWhenNoTokensToWithdraw() external {
+    test_WithdrawWhenWithdrawingAfterASwap();
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_bob);
     // it reverts
+    nativeToERC20Swapper.withdraw();
   }
 
   function test_WithdrawWhenCalledBeforeAnySwap() external {
     // it reverts or returns 0
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_bob);
+    // it reverts
+    nativeToERC20Swapper.withdraw();
   }
 
   function test_GetSwapTokenAmountWhenCalledAfterASwap() external {
+    test_SwapWhenSwappingNativeToERC20TokensToTheContract();
     // it returns the correct withdrawable amount for the user
-    // it returns 0 if user has no deposits
+    assertEq(nativeToERC20Swapper.getSwapTokenAmount(_bob), 2 ether);
   }
 
-  function test_GetSwapTokenAmountWhenCalledBeforeAnySwap() external {
+  function test_GetSwapTokenAmountWhenCalledBeforeAnySwap() external view {
     // it returns 0
+    assertEq(nativeToERC20Swapper.getSwapTokenAmount(_bob), 0);
   }
 
   function test_EmergencyWithdrawWhenWithdrawing() external {
@@ -315,7 +440,33 @@ contract UnitSwapperV2 is Test {
   }
 
   function test_SwapWhenUsersDepositsAndSwapsAndWithdrawsAndDepositsAgain() external {
+
+    test_WithdrawWhenWithdrawingAfterASwap();
+
+    vm.deal(_bob, 2 ether);
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 2 ether}(2 ether);
+
     // it tracks deposits and swaps per round
+    ISwapperV2.Deposits[] memory deposits = nativeToERC20Swapper.getDeposits(_bob);
+    assertEq(deposits.length, 1);
+
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
+
+    vm.prank(_owner);
+    nativeToERC20Swapper.swap();
+
+    ISwapperV2.SwapRateInfo memory swapRateInfo_x = nativeToERC20Swapper.getSwapRateInfo(0);
+    assertEq(swapRateInfo_x.totalDeposited, 1 ether);
+    assertEq(swapRateInfo_x.totalSwapped, 2 ether);
+
+    ISwapperV2.SwapRateInfo memory swapRateInfo_y = nativeToERC20Swapper.getSwapRateInfo(1);
+    assertEq(swapRateInfo_y.totalDeposited, 2 ether);
+    assertEq(swapRateInfo_y.totalSwapped, 4 ether);
+
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 2);
+    assertEq(nativeToERC20Swapper.getSwapTokenAmount(_bob), 4 ether);
+
     // it allows users to participate in multiple rounds
     // it calculates correct withdrawable amounts for each round
   }
@@ -323,24 +474,41 @@ contract UnitSwapperV2 is Test {
   function test_SwapWhenSomeUsersWithdrawBeforeSwapAndOthersAfter() external {
     // it only includes active deposits in the swap
     // it does not double-count or lose user funds
-  }
+    vm.deal(_bob, 1 ether);
+    vm.deal(_alice, 1 ether);
 
-  function _constructTokenPath(
-    address _depositedToken,
-    address _swappedToken
-  ) internal view returns (address[] memory path) {
-    path = new address[](2);
+    vm.prank(_bob);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
 
-    if (_depositedToken == address(0)) {
-      path[0] = IUniswapV2Router02(_mockRouter).WETH();
-    } else {
-      path[0] = _depositedToken;
-    }
+    vm.startPrank(_alice);
+    nativeToERC20Swapper.deposit{value: 1 ether}(1e18);
 
-    if (_swappedToken == address(0)) {
-      path[1] = IUniswapV2Router02(_mockRouter).WETH();
-    } else {
-      path[1] = _swappedToken;
-    }
+    // alice withdraws deposit 
+    nativeToERC20Swapper.withdrawDeposit();
+    vm.stopPrank();
+
+    vm.prank(_owner);
+    nativeToERC20Swapper.swap();
+
+    assertEq(nativeToERC20Swapper.getSwapIndex(), 1);
+    ISwapperV2.SwapRateInfo memory swapRateInfo = nativeToERC20Swapper.getSwapRateInfo(0);
+    assertEq(swapRateInfo.totalDeposited, 1 ether);
+    assertEq(swapRateInfo.totalSwapped, 2 ether);
+    
+    assertEq(nativeToERC20Swapper.getSwapTokenAmount(_bob), 2 ether);
+    assertEq(nativeToERC20Swapper.getSwapTokenAmount(_alice), 0);
+
+    // Alice attempt to withdraw
+    vm.expectRevert(ISwapperV2.Swapper_NoTokensToWithdraw.selector);
+    vm.prank(_alice);
+    nativeToERC20Swapper.withdraw();
+
+    vm.startPrank(_bob);
+
+    // it emits SwappedTokensWithdrawn
+    vm.expectEmit(true, true, true, true);
+    emit ISwapperV2.SwappedTokensWithdrawn(address(_bob), 2 ether);
+    nativeToERC20Swapper.withdraw();
+    
   }
 }

--- a/test/unit/SwapperV2.tree
+++ b/test/unit/SwapperV2.tree
@@ -37,7 +37,7 @@ SwapperV2::withdrawDeposit
 ├── when no tokens to withdraw
 │   └── it reverts
 ├── when called after swap for deposits already swapped
-│   └── it does not withdraw swapped deposits (only pre-swap deposits)
+│   └── it reverts
 └── when user has both pre-swap and post-swap deposits
     ├── it only withdraws pre-swap deposits
     └── it leaves post-swap deposits for future swaps

--- a/test/unit/SwapperV2.tree
+++ b/test/unit/SwapperV2.tree
@@ -1,0 +1,102 @@
+SwapperV2::constructor
+├── when passing valid tokens
+│   ├── it deploys
+│   ├── it sets the deposited token
+│   ├── it sets the swapped token
+│   └── it sets the router
+└── when passing same token for deposited and swapped
+    └── it reverts
+
+SwapperV2::deposit
+├── when passing valid native token amount
+│   ├── it deposits the amount to the contract
+│   ├── it appends a deposit entry for the user
+│   ├── it updates the balance of the contract
+│   └── it emits TokensDeposited
+├── when passing valid ERC20 token amount
+│   ├── it deposits the amount to the contract
+│   ├── it appends a deposit entry for the user
+│   ├── it updates the balance of the contract
+│   └── it emits TokensDeposited
+├── when depositing more than once
+│   ├── it appends multiple deposit entries for the user
+│   ├── it updates the balance of the contract
+│   └── it emits TokensDeposited for each deposit
+├── when passing amount of 0
+│   └── it reverts
+├── when balance of the contract is less than the amount sent
+│   └── it reverts
+└── when balance of the contract is greater than the amount sent
+    └── it reverts
+
+SwapperV2::withdrawDeposit
+├── when withdrawing before any swap
+│   ├── it returns the deposit token amount to the user
+│   ├── it deletes the user's deposit entries
+│   └── it emits DepositWithdrawn
+├── when no tokens to withdraw
+│   └── it reverts
+├── when called after swap for deposits already swapped
+│   └── it does not withdraw swapped deposits (only pre-swap deposits)
+└── when user has both pre-swap and post-swap deposits
+    ├── it only withdraws pre-swap deposits
+    └── it leaves post-swap deposits for future swaps
+
+SwapperV2::swap
+├── when swapping native to ERC20 tokens to the contract
+│   ├── it swaps via Uniswap V2 router
+│   ├── it records the swap rate for the round
+│   ├── it increments the swap index
+│   └── it emits TokensSwapped
+├── when swapping ERC20 to native token to the contract
+│   ├── it swaps via Uniswap V2 router
+│   ├── it records the swap rate for the round
+│   ├── it increments the swap index
+│   └── it emits TokensSwapped
+├── when swapping ERC20 to ERC20 tokens to the contract
+│   ├── it swaps via Uniswap V2 router
+│   ├── it records the swap rate for the round
+│   ├── it increments the swap index
+│   └── it emits TokensSwapped
+└──when called by a non-owner
+    └── it reverts
+
+SwapperV2::withdraw
+├── when withdrawing after a swap
+│   ├── it transfers the correct share of swapped tokens to the user
+│   ├── it deletes the user's deposit entries for swapped rounds
+│   └── it emits SwappedTokensWithdrawn
+├── when user has deposits from multiple rounds
+│   ├── it calculates and transfers the sum of all eligible swapped tokens
+│   └── it deletes all user's deposit entries
+├── when no tokens to withdraw
+│   └── it reverts
+└── when called before any swap
+    └── it reverts or returns 0
+
+SwapperV2::getSwapTokenAmount
+├── when called after a swap
+│   ├── it returns the correct withdrawable amount for the user
+│   └── it returns 0 if user has no deposits
+└──when called before any swap
+    └── it returns 0
+
+SwapperV2::emergencyWithdraw
+├── when withdrawing
+│   ├── it transfers the tokens to the owner
+│   └── it emits EmergencyWithdraw
+├── when passing amount of 0
+│   └── it reverts
+├── when called by a non-owner
+│   └── it reverts
+└── when passing amount greater than the balance
+    └── it reverts
+
+SwapperV2::swap
+├── when users deposits and swaps and withdraws and deposits again
+│   ├── it tracks deposits and swaps per round
+│   ├── it allows users to participate in multiple rounds
+│   └── it calculates correct withdrawable amounts for each round
+└── when some users withdraw before swap and others after
+    ├── it only includes active deposits in the swap
+    └── it does not double-count or lose user funds

--- a/yarn.lock
+++ b/yarn.lock
@@ -171,6 +171,28 @@
     "@types/conventional-commits-parser" "^5.0.0"
     chalk "^5.3.0"
 
+"@defi-wonderland/smock-foundry@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@defi-wonderland/smock-foundry/-/smock-foundry-1.5.0.tgz#e0f91cb40a1805644fbe1bcec8bbb6556d72253c"
+  integrity sha512-GjMc8Tgg+jBzV0zp00WTSlExptthocrnE3FY58Zm4Li+jWwrphKRflGRf4F65f1t976SNIW63mleWJViFa4mRA==
+  dependencies:
+    fast-glob "3.3.2"
+    handlebars "4.7.7"
+    solc-typed-ast "18.1.3"
+    yargs "17.7.2"
+
+"@noble/curves@1.4.2", "@noble/curves@~1.4.0":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.4.2.tgz#40309198c76ed71bc6dbf7ba24e81ceb4d0d1fe9"
+  integrity sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==
+  dependencies:
+    "@noble/hashes" "1.4.0"
+
+"@noble/hashes@1.4.0", "@noble/hashes@~1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.4.0.tgz#45814aa329f30e4fe0ba49426f49dfccdd066426"
+  integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -196,6 +218,28 @@
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-5.3.0.tgz#0a90ce16f5c855e3c8239691f1722cd4999ae741"
   integrity sha512-zj/KGoW7zxWUE8qOI++rUM18v+VeLTTzKs/DJFkSzHpQFPD/jKKF0TrMxBfGLl3kpdELCNccvB3zmofSzm4nlA==
+
+"@scure/base@~1.1.6":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
+
+"@scure/bip32@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.4.0.tgz#4e1f1e196abedcef395b33b9674a042524e20d67"
+  integrity sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==
+  dependencies:
+    "@noble/curves" "~1.4.0"
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
+
+"@scure/bip39@1.3.0":
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.3.0.tgz#0f258c16823ddd00739461ac31398b4e7d6a18c3"
+  integrity sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==
+  dependencies:
+    "@noble/hashes" "~1.4.0"
+    "@scure/base" "~1.1.6"
 
 "@solidity-parser/parser@^0.19.0":
   version "0.19.0"
@@ -241,6 +285,11 @@ JSONStream@^1.3.5:
   dependencies:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
+
+abitype@0.7.1:
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-0.7.1.tgz#16db20abe67de80f6183cf75f3de1ff86453b745"
+  integrity sha512-VBkRHTDZf9Myaek/dO3yMmOzB/y2s3Zo6nVU7yaw1G+TvCHAjwaJzNGN9yo4K5D8bU/VZXKP1EJpRhFr862PlQ==
 
 ajv@^6.12.6:
   version "6.12.6"
@@ -316,6 +365,27 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
+available-typed-arrays@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz#a5cc375d6a03c2efc87a553f3e0b1522def14846"
+  integrity sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==
+  dependencies:
+    possible-typed-array-names "^1.0.0"
+
+axios@^1.6.8:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-1.9.0.tgz#25534e3b72b54540077d33046f77e3b8d7081901"
+  integrity sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==
+  dependencies:
+    follow-redirects "^1.15.6"
+    form-data "^4.0.0"
+    proxy-from-env "^1.1.0"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -334,6 +404,32 @@ braces@^3.0.3:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
+
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+call-bind@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
+  integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
+  dependencies:
+    call-bind-apply-helpers "^1.0.0"
+    es-define-property "^1.0.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.2"
+
+call-bound@^1.0.2, call-bound@^1.0.3, call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
 
 callsites@^3.0.0:
   version "3.1.0"
@@ -394,15 +490,37 @@ colorette@^2.0.20:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
   integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
+command-exists@^1.2.8:
+  version "1.2.9"
+  resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.9.tgz#c50725af3808c8ab0260fd60b01fbfa25b954f69"
+  integrity sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==
+
 commander@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-11.1.0.tgz#62fdce76006a68e5c1ab3314dc92e800eb83d906"
   integrity sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==
 
+commander@^12.0.0:
+  version "12.1.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
+  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+
 commander@^14.0.0:
   version "14.0.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.0.tgz#f244fc74a92343514e56229f16ef5c5e22ced5e9"
   integrity sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==
+
+commander@^8.1.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
+  integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
 compare-func@^2.0.0:
   version "2.0.0"
@@ -484,6 +602,30 @@ debug@^4.4.1:
   dependencies:
     ms "^2.1.3"
 
+decimal.js@^10.4.3:
+  version "10.5.0"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.5.0.tgz#0f371c7cf6c4898ce0afb09836db73cd82010f22"
+  integrity sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw==
+
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+detect-file@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/detect-file/-/detect-file-1.0.0.tgz#f0d66d03672a825cb1b73bdb3fe62310c8e552b7"
+  integrity sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==
+
 detect-indent@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.1.tgz#cbb060a12842b9c4d333f1cac4aa4da1bb66bc25"
@@ -507,6 +649,15 @@ dot-prop@^5.1.0:
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
   dependencies:
     is-obj "^2.0.0"
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
 
 emoji-regex@^10.3.0:
   version "10.4.0"
@@ -535,10 +686,47 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-define-property@^1.0.0, es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
+
+es-set-tostringtag@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
+  dependencies:
+    es-errors "^1.3.0"
+    get-intrinsic "^1.2.6"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 escalade@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
   integrity sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==
+
+ethereum-cryptography@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-2.2.1.tgz#58f2810f8e020aecb97de8c8c76147600b0b8ccf"
+  integrity sha512-r/W8lkHSiTLxUxW8Rf3u4HGB0xQweG2RyETjywylKZSzLWoWAijRz8WCuOtJ6wah+avllXBqZuk29HCCvhEIRg==
+  dependencies:
+    "@noble/curves" "1.4.2"
+    "@noble/hashes" "1.4.0"
+    "@scure/bip32" "1.4.0"
+    "@scure/bip39" "1.3.0"
 
 eventemitter3@^5.0.1:
   version "5.0.1"
@@ -560,6 +748,13 @@ execa@^8.0.1:
     signal-exit "^4.1.0"
     strip-final-newline "^3.0.0"
 
+expand-tilde@^2.0.0, expand-tilde@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/expand-tilde/-/expand-tilde-2.0.2.tgz#97e801aa052df02454de46b02bf621642cdc8502"
+  integrity sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==
+  dependencies:
+    homedir-polyfill "^1.0.1"
+
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -569,6 +764,17 @@ fast-diff@^1.2.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
+
+fast-glob@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.2.tgz#a904501e57cfdd2ffcded45e99a54fef55e46129"
+  integrity sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.4"
 
 fast-glob@^3.3.0:
   version "3.3.3"
@@ -614,14 +820,60 @@ find-up@^7.0.0:
     path-exists "^5.0.0"
     unicorn-magic "^0.1.0"
 
+findup-sync@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-5.0.0.tgz#54380ad965a7edca00cc8f63113559aadc541bd2"
+  integrity sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==
+  dependencies:
+    detect-file "^1.0.0"
+    is-glob "^4.0.3"
+    micromatch "^4.0.4"
+    resolve-dir "^1.0.1"
+
+follow-redirects@^1.12.1, follow-redirects@^1.15.6:
+  version "1.15.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
+  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
+
+for-each@^0.3.5:
+  version "0.3.5"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.5.tgz#d650688027826920feeb0af747ee7b9421a41d47"
+  integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
+  dependencies:
+    is-callable "^1.2.7"
+
 "forge-std@github:foundry-rs/forge-std#1.9.2":
   version "1.9.2"
   resolved "https://codeload.github.com/foundry-rs/forge-std/tar.gz/1714bee72e286e73f76e320d110e0eaf5c4e649d"
+
+form-data@^4.0.0:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.2.tgz#35cabbdd30c3ce73deb2c42d3c8d3ed9ca51794c"
+  integrity sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    es-set-tostringtag "^2.1.0"
+    mime-types "^2.1.12"
+
+fs-extra@^11.2.0:
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-11.3.0.tgz#0daced136bbaf65a555a326719af931adc7a314d"
+  integrity sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
+
+function-bind@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -632,6 +884,30 @@ get-east-asian-width@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz#21b4071ee58ed04ee0db653371b55b4299875389"
   integrity sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==
+
+get-intrinsic@^1.2.4, get-intrinsic@^1.2.6, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
+get-proto@^1.0.0, get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stdin@^9.0.0:
   version "9.0.0"
@@ -682,6 +958,26 @@ global-directory@^4.0.1:
   dependencies:
     ini "4.1.1"
 
+global-modules@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/global-modules/-/global-modules-1.0.0.tgz#6d770f0eb523ac78164d72b5e71a8877265cc3ea"
+  integrity sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==
+  dependencies:
+    global-prefix "^1.0.1"
+    is-windows "^1.0.1"
+    resolve-dir "^1.0.0"
+
+global-prefix@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/global-prefix/-/global-prefix-1.0.2.tgz#dbf743c6c14992593c655568cb66ed32c0122ebe"
+  integrity sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==
+  dependencies:
+    expand-tilde "^2.0.2"
+    homedir-polyfill "^1.0.1"
+    ini "^1.3.4"
+    is-windows "^1.0.1"
+    which "^1.2.14"
+
 globby@^13.1.2:
   version "13.2.2"
   resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
@@ -693,14 +989,69 @@ globby@^13.1.2:
     merge2 "^1.4.1"
     slash "^4.0.0"
 
+gopd@^1.0.1, gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+graceful-fs@^4.1.6, graceful-fs@^4.2.0:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
 "halmos-cheatcodes@github:a16z/halmos-cheatcodes#c0d8655":
   version "0.0.0"
   resolved "https://codeload.github.com/a16z/halmos-cheatcodes/tar.gz/c0d865508c0fee0a11b97732c5e90f9cad6b65a5"
+
+handlebars@4.7.7:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
+  dependencies:
+    minimist "^1.2.5"
+    neo-async "^2.6.0"
+    source-map "^0.6.1"
+    wordwrap "^1.0.0"
+  optionalDependencies:
+    uglify-js "^3.1.4"
 
 has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
+
+has-symbols@^1.0.3, has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
+has-tostringtag@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
+  dependencies:
+    has-symbols "^1.0.3"
+
+hasown@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
+  dependencies:
+    function-bind "^1.1.2"
+
+homedir-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
 
 human-signals@^5.0.0:
   version "5.0.0"
@@ -738,7 +1089,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -748,10 +1099,28 @@ ini@4.1.1:
   resolved "https://registry.yarnpkg.com/ini/-/ini-4.1.1.tgz#d95b3d843b1e906e56d6747d5447904ff50ce7a1"
   integrity sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==
 
+ini@^1.3.4:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
+  integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+
+is-arguments@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/is-arguments/-/is-arguments-1.2.0.tgz#ad58c6aecf563b78ef2bf04df540da8f5d7d8e1b"
+  integrity sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==
+  dependencies:
+    call-bound "^1.0.2"
+    has-tostringtag "^1.0.2"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
+
+is-callable@^1.2.7:
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
+  integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
 
 is-extglob@^2.1.1:
   version "2.1.1"
@@ -775,7 +1144,17 @@ is-fullwidth-code-point@^5.0.0:
   dependencies:
     get-east-asian-width "^1.0.0"
 
-is-glob@^4.0.1:
+is-generator-function@^1.0.7:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-generator-function/-/is-generator-function-1.1.0.tgz#bf3eeda931201394f57b5dba2800f91a238309ca"
+  integrity sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==
+  dependencies:
+    call-bound "^1.0.3"
+    get-proto "^1.0.0"
+    has-tostringtag "^1.0.2"
+    safe-regex-test "^1.1.0"
+
+is-glob@^4.0.1, is-glob@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -797,6 +1176,16 @@ is-plain-obj@^4.1.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.1.0.tgz#d65025edec3657ce032fd7db63c97883eaed71f0"
   integrity sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==
 
+is-regex@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.2.1.tgz#76d70a3ed10ef9be48eb577887d74205bf0cad22"
+  integrity sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==
+  dependencies:
+    call-bound "^1.0.2"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+    hasown "^2.0.2"
+
 is-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-3.0.0.tgz#e6bfd7aa6bef69f4f472ce9bb681e3e57b4319ac"
@@ -809,6 +1198,18 @@ is-text-path@^2.0.0:
   dependencies:
     text-extensions "^2.0.0"
 
+is-typed-array@^1.1.3:
+  version "1.1.15"
+  resolved "https://registry.yarnpkg.com/is-typed-array/-/is-typed-array-1.1.15.tgz#4bfb4a45b61cee83a5a46fba778e4e8d59c0ce0b"
+  integrity sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==
+  dependencies:
+    which-typed-array "^1.1.16"
+
+is-windows@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+  integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -818,6 +1219,11 @@ jiti@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.4.2.tgz#d19b7732ebb6116b06e2038da74a55366faef560"
   integrity sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==
+
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -830,6 +1236,11 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsel@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/jsel/-/jsel-1.1.6.tgz#9257fee6c6e8ad8e75d5706503fe84f376035896"
+  integrity sha512-7E6r8kVzjmKhwXR/82Z+43edfOJGRvLvx6cJZ+SS2MGAPPtYZGnaIsFHpQMA1IbIPA9twDProkob4IIAJ0ZqSw==
 
 json-parse-even-better-errors@^2.3.0:
   version "2.3.1"
@@ -845,6 +1256,15 @@ json-schema-traverse@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
 
 jsonparse@^1.2.0:
   version "1.3.1"
@@ -962,6 +1382,16 @@ log-update@^6.1.0:
     strip-ansi "^7.1.0"
     wrap-ansi "^9.0.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+memorystream@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
+  integrity sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==
+
 meow@^12.0.1:
   version "12.1.1"
   resolved "https://registry.yarnpkg.com/meow/-/meow-12.1.1.tgz#e558dddbab12477b69b2e9a2728c327f191bace6"
@@ -977,13 +1407,25 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-micromatch@^4.0.8:
+micromatch@^4.0.4, micromatch@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
+
+mime-db@1.52.0:
+  version "1.52.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
+
+mime-types@^2.1.12:
+  version "2.1.35"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
+  dependencies:
+    mime-db "1.52.0"
 
 mimic-fn@^4.0.0:
   version "4.0.0"
@@ -1002,7 +1444,7 @@ minimatch@^5.0.1:
   dependencies:
     brace-expansion "^2.0.1"
 
-minimist@^1.2.8:
+minimist@^1.2.5, minimist@^1.2.8:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.8.tgz#c1a464e7693302e082a075cee0c057741ac4772c"
   integrity sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==
@@ -1016,6 +1458,11 @@ nano-spawn@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/nano-spawn/-/nano-spawn-1.0.2.tgz#9853795681f0e96ef6f39104c2e4347b6ba79bf6"
   integrity sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==
+
+neo-async@^2.6.0:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 npm-run-path@^5.1.0:
   version "5.3.0"
@@ -1044,6 +1491,11 @@ onetime@^7.0.0:
   integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
   dependencies:
     mimic-function "^5.0.0"
+
+os-tmpdir@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
+  integrity sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==
 
 p-limit@^4.0.0:
   version "4.0.0"
@@ -1075,6 +1527,11 @@ parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-passwd@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-passwd/-/parse-passwd-1.0.0.tgz#6d5b934a456993b23d37f40a382d6f1666a8e5c6"
+  integrity sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==
 
 path-exists@^5.0.0:
   version "5.0.0"
@@ -1116,10 +1573,20 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
+possible-typed-array-names@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz#93e3582bc0e5426586d9d07b79ee40fc841de4ae"
+  integrity sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==
+
 prettier@^2.8.3:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+
+proxy-from-env@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 punycode@^2.1.0:
   version "2.3.1"
@@ -1140,6 +1607,14 @@ require-from-string@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+
+resolve-dir@^1.0.0, resolve-dir@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/resolve-dir/-/resolve-dir-1.0.1.tgz#79a40644c362be82f26effe739c9bb5382046f43"
+  integrity sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==
+  dependencies:
+    expand-tilde "^2.0.0"
+    global-modules "^1.0.0"
 
 resolve-from@^4.0.0:
   version "4.0.0"
@@ -1176,6 +1651,20 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
+safe-regex-test@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/safe-regex-test/-/safe-regex-test-1.1.0.tgz#7f87dfb67a3150782eaaf18583ff5d1711ac10c1"
+  integrity sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==
+  dependencies:
+    call-bound "^1.0.2"
+    es-errors "^1.3.0"
+    is-regex "^1.2.1"
+
+semver@^5.5.0:
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
+  integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
+
 semver@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
@@ -1185,6 +1674,18 @@ semver@^7.6.0:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
+
+set-function-length@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -1233,6 +1734,35 @@ slice-ansi@^7.1.0:
     ansi-styles "^6.2.1"
     is-fullwidth-code-point "^5.0.0"
 
+solc-typed-ast@18.1.3:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/solc-typed-ast/-/solc-typed-ast-18.1.3.tgz#243cc0c5a4f701445ac10341224bf8c18a6ed252"
+  integrity sha512-11iBtavJJtkzrmQdlAiZ7sz3C3WOQ8MaN7+r4b9C6B/3ORqg4oTUW5/ANyGyus5ppXDXzPyT90BYCfP73df3HA==
+  dependencies:
+    axios "^1.6.8"
+    commander "^12.0.0"
+    decimal.js "^10.4.3"
+    findup-sync "^5.0.0"
+    fs-extra "^11.2.0"
+    jsel "^1.1.6"
+    semver "^7.6.0"
+    solc "0.8.25"
+    src-location "^1.1.0"
+    web3-eth-abi "^4.2.0"
+
+solc@0.8.25:
+  version "0.8.25"
+  resolved "https://registry.yarnpkg.com/solc/-/solc-0.8.25.tgz#393f3101617388fb4ba2a58c5b03ab02678e375c"
+  integrity sha512-7P0TF8gPeudl1Ko3RGkyY6XVCxe2SdD/qQhtns1vl3yAbK/PDifKDLHGtx1t7mX3LgR7ojV7Fg/Kc6Q9D2T8UQ==
+  dependencies:
+    command-exists "^1.2.8"
+    commander "^8.1.0"
+    follow-redirects "^1.12.1"
+    js-sha3 "0.8.0"
+    memorystream "^0.3.1"
+    semver "^5.5.0"
+    tmp "0.0.33"
+
 solhint-community@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/solhint-community/-/solhint-community-4.0.1.tgz#5a0a47511185d2b5555db289bfd72caf935266ae"
@@ -1277,10 +1807,20 @@ sort-package-json@2.10.0:
     semver "^7.6.0"
     sort-object-keys "^1.1.3"
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 split2@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
+
+src-location@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/src-location/-/src-location-1.1.0.tgz#3f50eeb0c7169432e55b426be6e3a68ebba16218"
+  integrity sha512-idBVZgLZGzB3B2Et317AFDQto7yRgp1tOuFd+VKIH2dw1jO1b6p07zNjtQoVhkW+CY6oGTp9Y5UIfbJoZRsoFQ==
 
 string-argv@^0.3.2:
   version "0.3.2"
@@ -1362,12 +1902,24 @@ tinyexec@^1.0.0:
   resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.1.tgz#70c31ab7abbb4aea0a24f55d120e5990bfa1e0b1"
   integrity sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==
 
+tmp@0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
+
 to-regex-range@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/to-regex-range/-/to-regex-range-5.0.1.tgz#1648c44aae7c8d988a326018ed72f5b4dd0392e4"
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+uglify-js@^3.1.4:
+  version "3.19.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
+  integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
 undici-types@~6.21.0:
   version "6.21.0"
@@ -1379,6 +1931,11 @@ unicorn-magic@^0.1.0:
   resolved "https://registry.yarnpkg.com/unicorn-magic/-/unicorn-magic-0.1.0.tgz#1bb9a51c823aaf9d73a8bfcd3d1a23dde94b0ce4"
   integrity sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==
 
+universalify@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
+  integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
+
 uri-js@^4.2.2:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
@@ -1386,12 +1943,93 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+util@^0.12.5:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.12.5.tgz#5f17a6059b73db61a875668781a1c2b136bd6fbc"
+  integrity sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==
+  dependencies:
+    inherits "^2.0.3"
+    is-arguments "^1.0.4"
+    is-generator-function "^1.0.7"
+    is-typed-array "^1.1.3"
+    which-typed-array "^1.1.2"
+
+web3-errors@^1.2.0, web3-errors@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/web3-errors/-/web3-errors-1.3.1.tgz#163bc4d869f98614760b683d733c3ed1fb415d98"
+  integrity sha512-w3NMJujH+ZSW4ltIZZKtdbkbyQEvBzyp3JRn59Ckli0Nz4VMsVq8aF1bLWM7A2kuQ+yVEm3ySeNU+7mSRwx7RQ==
+  dependencies:
+    web3-types "^1.10.0"
+
+web3-eth-abi@^4.2.0:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-4.4.1.tgz#1dca9d80341b3cd7a1ae07dc98080c2073d62a29"
+  integrity sha512-60ecEkF6kQ9zAfbTY04Nc9q4eEYM0++BySpGi8wZ2PD1tw/c0SDvsKhV6IKURxLJhsDlb08dATc3iD6IbtWJmg==
+  dependencies:
+    abitype "0.7.1"
+    web3-errors "^1.3.1"
+    web3-types "^1.10.0"
+    web3-utils "^4.3.3"
+    web3-validator "^2.0.6"
+
+web3-types@^1.10.0, web3-types@^1.6.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/web3-types/-/web3-types-1.10.0.tgz#41b0b4d2dd75e919d5b6f37bf139e29f445db04e"
+  integrity sha512-0IXoaAFtFc8Yin7cCdQfB9ZmjafrbP6BO0f0KT/khMhXKUpoJ6yShrVhiNpyRBo8QQjuOagsWzwSK2H49I7sbw==
+
+web3-utils@^4.3.3:
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-4.3.3.tgz#e380a1c03a050d3704f94bd08c1c9f50a1487205"
+  integrity sha512-kZUeCwaQm+RNc2Bf1V3BYbF29lQQKz28L0y+FA4G0lS8IxtJVGi5SeDTUkpwqqkdHHC7JcapPDnyyzJ1lfWlOw==
+  dependencies:
+    ethereum-cryptography "^2.0.0"
+    eventemitter3 "^5.0.1"
+    web3-errors "^1.3.1"
+    web3-types "^1.10.0"
+    web3-validator "^2.0.6"
+
+web3-validator@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/web3-validator/-/web3-validator-2.0.6.tgz#a0cdaa39e1d1708ece5fae155b034e29d6a19248"
+  integrity sha512-qn9id0/l1bWmvH4XfnG/JtGKKwut2Vokl6YXP5Kfg424npysmtRLe9DgiNBM9Op7QL/aSiaA0TVXibuIuWcizg==
+  dependencies:
+    ethereum-cryptography "^2.0.0"
+    util "^0.12.5"
+    web3-errors "^1.2.0"
+    web3-types "^1.6.0"
+    zod "^3.21.4"
+
+which-typed-array@^1.1.16, which-typed-array@^1.1.2:
+  version "1.1.19"
+  resolved "https://registry.yarnpkg.com/which-typed-array/-/which-typed-array-1.1.19.tgz#df03842e870b6b88e117524a4b364b6fc689f956"
+  integrity sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==
+  dependencies:
+    available-typed-arrays "^1.0.7"
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    for-each "^0.3.5"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-tostringtag "^1.0.2"
+
+which@^1.2.14:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
+  integrity sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+  dependencies:
+    isexe "^2.0.0"
+
 which@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+wordwrap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+  integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
 wrap-ansi@^7.0.0:
   version "7.0.0"
@@ -1431,7 +2069,7 @@ yargs-parser@^21.1.1:
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@^17.0.0:
+yargs@17.7.2, yargs@^17.0.0:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -1448,3 +2086,8 @@ yocto-queue@^1.0.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.1.tgz#36d7c4739f775b3cbc28e6136e21aa057adec418"
   integrity sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==
+
+zod@^3.21.4:
+  version "3.25.51"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.25.51.tgz#aa2cf648e54f6f060f139cf77b694819f63c9f3a"
+  integrity sha512-TQSnBldh+XSGL+opiSIq0575wvDPqu09AqWe1F7JhUMKY+M91/aGlK4MhpVNO7MgYfHcVCB1ffwAUTJzllKJqg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -216,6 +216,24 @@
   dependencies:
     undici-types "~6.21.0"
 
+"@uniswap/lib@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@uniswap/lib/-/lib-1.1.1.tgz#0afd29601846c16e5d082866cbb24a9e0758e6bc"
+  integrity sha512-2yK7sLpKIT91TiS5sewHtOa7YuM8IuBXVl4GZv2jZFys4D2sY7K5vZh6MqD25TPA95Od+0YzCVq6cTF2IKrOmg==
+
+"@uniswap/v2-core@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/v2-core/-/v2-core-1.0.0.tgz#e0fab91a7d53e8cafb5326ae4ca18351116b0844"
+  integrity sha512-BJiXrBGnN8mti7saW49MXwxDBRFiWemGetE58q8zgfnPPzQKq55ADltEILqOt6VFZ22kVeVKbF8gVd8aY3l7pA==
+
+"@uniswap/v2-periphery@^1.1.0-beta.0":
+  version "1.1.0-beta.0"
+  resolved "https://registry.yarnpkg.com/@uniswap/v2-periphery/-/v2-periphery-1.1.0-beta.0.tgz#20a4ccfca22f1a45402303aedb5717b6918ebe6d"
+  integrity sha512-6dkwAMKza8nzqYiXEr2D86dgW3TTavUvCR0w2Tu33bAbM8Ah43LKAzH7oKKPRT5VJQaMi1jtkGs1E8JPor1n5g==
+  dependencies:
+    "@uniswap/lib" "1.1.1"
+    "@uniswap/v2-core" "1.0.0"
+
 JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
NOTE: this assume the swap rate has to be preserved for each deposit.
The smarter way would be to avoid tracking swap rates after every swap. Instead follow what syntheix does where all deposits are pooled together and swap rate is averaged across all donations which haven't been withdrawn.( This means after every swap, the user's withdrawable amount will vary based on the swap rate)

- Enable multiple swapping
- Keep track of swap rates for each swap
- Wire in Uniswap V2 for all sorta swaps 



Music while coding : https://open.spotify.com/track/3ZOEytgrvLwQaqXreDs2Jx?si=92cf9bf5e1a44589 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced the SwapperV2 contract, enabling users to deposit and swap tokens or ETH via Uniswap V2, with support for multiple deposit and withdrawal scenarios.
  - Added a new interface for SwapperV2, detailing events, errors, and core functions for deposit, swap, and withdrawal operations.

- **Bug Fixes**
  - Standardized error names by removing version suffixes for improved clarity and consistency.

- **Tests**
  - Added comprehensive unit and integration tests for SwapperV2, covering all deposit, swap, withdrawal, and emergency scenarios.
  - Introduced a mock Uniswap V2 router for robust testing of swap interactions.

- **Chores**
  - Updated dependencies and remappings to support new Uniswap and testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->